### PR TITLE
Header/Footer 컴포넌트 생성

### DIFF
--- a/.github/chromatic.yml
+++ b/.github/chromatic.yml
@@ -1,22 +1,44 @@
-# Workflow name
-name: "Chromatic Deployment"
+name: "Chromatic"
 
-# Event for the workflow
-on: push
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - '**.stories.tsx'
+  push:
+    branches: [develop]
+    paths:
+      - '**.stories.tsx'
 
-# List of jobs
 jobs:
-  test:
-    # Operating System
+  chromatic:
     runs-on: ubuntu-latest
-    # Job steps
     steps:
-      - uses: actions/checkout@v1
-      - run: yarn
-        #👇 Adds Chromatic as a step in the workflow
-      - uses: chromaui/action@v1
-        # Options required for Chromatic's GitHub Action
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/ko/deploy/ to obtain it
+          fetch-depth: 0
+
+       - name: cache dependencies
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-storybook
+
+      - name: depedency install
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Publish to Chromatic
+        id: chromatic
+        uses: chromaui/action@latest
+        with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+
+       - name: comment PR
+        uses: thollander/actions-comment-pull-request@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message: '🚀storybook: ${{ steps.chromatic.outputs.storybookUrl }}'

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from "@storybook/nextjs";
+import path from "path";
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
@@ -18,6 +19,12 @@ const config: StorybookConfig = {
   },
   webpackFinal: async (config) => {
     const imageRule = config.module?.rules?.find((rule) => {
+      if (config.resolve) {
+        config.resolve.alias = {
+          ...config.resolve.alias,
+          "@": path.resolve(__dirname, "../src"),
+        };
+      }
       const test = (rule as { test: RegExp }).test;
 
       if (!test) {

--- a/src/app/components/Button/Button.stories.tsx
+++ b/src/app/components/Button/Button.stories.tsx
@@ -3,12 +3,12 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "./Button";
 
 const meta: Meta<typeof Button> = {
-  title: "components/atoms/button",
+  title: "components/Button",
   component: Button,
   argTypes: {
     variant: {
       control: "inline-radio",
-      options: ["main", "empty"],
+      options: ["main", "empty", "none"],
     },
     rounded: {
       control: "inline-radio",

--- a/src/app/components/Button/Button.tsx
+++ b/src/app/components/Button/Button.tsx
@@ -8,6 +8,7 @@ const buttonVariants = cva(
       variant: {
         main: "bg-brown-50 text-white hover:bg-brown-60",
         empty: "bg-white text-gray-50 border-2 border-gray-40",
+        none: "text-white",
       },
       rounded: {
         none: "rounded-none",

--- a/src/app/components/Footer/Footer.tsx
+++ b/src/app/components/Footer/Footer.tsx
@@ -1,5 +1,0 @@
-const Footer = () => {
-  return <div>Footer</div>;
-};
-
-export default Footer; 

--- a/src/app/components/Input/Input.stories.tsx
+++ b/src/app/components/Input/Input.stories.tsx
@@ -5,7 +5,7 @@ import { Input } from "./Input";
 import { useInput } from "../../../hook/useInput";
 
 const meta: Meta<typeof Input> = {
-  title: "components/atoms/input",
+  title: "components/Input",
   component: Input,
   argTypes: {
     variant: {

--- a/src/app/components/Layout/Footer/Footer.stories.tsx
+++ b/src/app/components/Layout/Footer/Footer.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Footer } from "./Footer";
+
+const meta: Meta<typeof Footer> = {
+  title: "components/Footer",
+  component: Footer,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Footer>;
+
+export const BasicFooter: Story = {};

--- a/src/app/components/Layout/Footer/Footer.tsx
+++ b/src/app/components/Layout/Footer/Footer.tsx
@@ -1,0 +1,12 @@
+export const Footer = () => {
+  return (
+    <div className="flex flex-col text-white font-[700] gap-[20px] px-[100px] py-[50px] w-[100%] min-h-[200px] bg-brown-50">
+      <div>서비스 이용약관 | 개인정보 처리 방침 | 회사 안내</div>
+      <div className="flex flex-col">
+        <div>고객센터 |</div>
+        <div>제휴 및 대외 협력 | https://jisungin.co.kr</div>
+      </div>
+      <div>지성인 JISUNGIN 2024 by JISUNGIN All rights reserved</div>
+    </div>
+  );
+};

--- a/src/app/components/Layout/Header/Header.stories.tsx
+++ b/src/app/components/Layout/Header/Header.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Header } from "./Header";
+
+const meta: Meta<typeof Header> = {
+  title: "components/Header",
+  component: Header,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Header>;
+
+export const BasicHeader: Story = {};

--- a/src/app/components/Layout/Header/Header.tsx
+++ b/src/app/components/Layout/Header/Header.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useInput } from "@/hook/useInput";
+import { Button } from "../../Button/Button";
+import { Input } from "../../Input/Input";
+
+export const Header = () => {
+  const { value, handleChange, reset } = useInput("");
+
+  return (
+    <div className="flex fixed top-0 items-center w-full px-[28px] h-[85px] bg-brown-60">
+      <div className="flex font-GmarketSans font-[500] items-center text-white text-4xl flex-1">
+        JISUNGIN
+      </div>
+      <div className="w-[414px]">
+        <Input
+          value={value}
+          onChange={handleChange}
+          reset={reset}
+          placeholder="이곳에 검색해보세요."
+        />
+      </div>
+      <div className="flex">
+        <div className="w-[100px]">
+          <Button variant="none">로그인</Button>
+        </div>
+        <div className="w-[100px]">
+          <Button variant="none">회원가입</Button>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## 🤷‍♂️ 해결하려 했던 문제는 무엇인가요?
Related #3 
Header/Footer 컴포넌트 생성
## ⚒️ 무엇이 바뀌었나요?
Header/Footer 컴포넌트를 생성하였습니다. 
## 👏 이 부분에 집중해주셨음 좋겠어요!
 - Footer는 중간의 content에 상관없이 맨 아래 레이아웃에 배치할 예정입니다. 
 - 또한 해당 컴포넌트들을 app/layout.tsx 파일에 적용 시켜 놓겠습니다.
 - Header의 로고는 아직 글씨체 적용 안되었습니다.
## 📷 캡처 사진
### Header
<img width="1274" alt="image" src="https://github.com/jisung-in/frontend/assets/55770796/bf1edbb3-f926-4e45-8929-7d1593e1904d">

### Footer
<img width="1268" alt="image" src="https://github.com/jisung-in/frontend/assets/55770796/c9f359ef-aca1-4489-9a81-c8cb571cea4e">

## 📚 참고해주세요
- [x] git pull