### PR TITLE
데이터 추가로 인한 typescript 수정 작업, 토크방, 의견, 평가에 대한 삭제 기능 추가

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,4 +17,13 @@ module.exports = {
 
     return config;
   },
+  async redirects() {
+    return [
+      {
+        source: "/book",
+        destination: "/not-found",
+        permanent: false,
+      },
+    ];
+  },
 };

--- a/src/app/book/[isbn]/page.tsx
+++ b/src/app/book/[isbn]/page.tsx
@@ -81,6 +81,7 @@ const page = ({ params }: { params: { isbn: string } }) => {
           <BookInformation
             data={bookDetailData}
             isbn={params.isbn}
+            isLogin={isLoggedIn}
             onTotalRatingChange={totalRatingChange}
           />
         ) : (
@@ -90,7 +91,7 @@ const page = ({ params }: { params: { isbn: string } }) => {
 
       <div className="bg-white">
         <div className="max-w-[1680px] mx-[120px]">
-          <RegisterEvaluation isbn={params.isbn} />
+          <RegisterEvaluation isbn={params.isbn} isLogin={isLoggedIn} />
 
           <div className="flex flex-row mt-[63px] mb-[28px] items-center">
             <div className="flex flex-row gap-x-[19px] flex-grow text-[30px] font-SpoqaHanSansNeo items-center">

--- a/src/app/book/[isbn]/page.tsx
+++ b/src/app/book/[isbn]/page.tsx
@@ -32,6 +32,7 @@ type TalkRoom = {
 type UserEvaluation = {
   reviewId: number;
   ratingId: number;
+  creatorId: number;
   username: string;
   profileImage: string;
   reviewContent: string;

--- a/src/app/book/[isbn]/page.tsx
+++ b/src/app/book/[isbn]/page.tsx
@@ -8,6 +8,7 @@ import { useGetBookInformation } from "@/hook/reactQuery/book/useGetBookInformat
 import { useGetBookRelatedTalkRoom } from "@/hook/reactQuery/book/useGetBookRelatedTalkRoom";
 import { useGetReview } from "@/hook/reactQuery/book/useGetReview";
 import { useGetReviewLike } from "@/hook/reactQuery/book/useGetReviewLike";
+import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
 import { useGetRoomLike } from "@/hook/reactQuery/talkRoom/useGetRoomLike";
 import { useLogin } from "@/hook/useLogin";
 import Link from "next/link";
@@ -48,6 +49,9 @@ const page = ({ params }: { params: { isbn: string } }) => {
   const { data: reviewLikeIds } = isLoggedIn
     ? useGetReviewLike()
     : { data: { reviewIds: [] } };
+  const { data: myDetailData } = isLoggedIn
+    ? useGetMyDetail()
+    : { data: { userId: -1, userImage: "", userName: "" } };
   const { data: bookDetailData, refetch: refetchBookInformation } =
     useGetBookInformation({
       isbn: params.isbn,
@@ -111,6 +115,7 @@ const page = ({ params }: { params: { isbn: string } }) => {
                     <MiniEvaluationCard
                       key={data.reviewId}
                       data={data}
+                      userId={myDetailData?.userId || -1}
                       isLike={isLike}
                     />
                   );
@@ -144,6 +149,7 @@ const page = ({ params }: { params: { isbn: string } }) => {
                 <RelatedTalkRoomCard
                   key={data.id}
                   data={data}
+                  userId={myDetailData?.userId || -1}
                   isLike={isLike}
                 />
               );

--- a/src/app/book/[isbn]/page.tsx
+++ b/src/app/book/[isbn]/page.tsx
@@ -27,6 +27,7 @@ type TalkRoom = {
   likeCount: number;
   readingStatuses: string[];
   registeredDateTime?: string;
+  creatorId: number;
 };
 type UserEvaluation = {
   reviewId: number;

--- a/src/app/book/_component/BookInformation.tsx
+++ b/src/app/book/_component/BookInformation.tsx
@@ -17,12 +17,14 @@ type BookInformation = {
 type BookInformationProps = {
   data: BookInformation;
   isbn: string;
+  isLogin: boolean;
   onTotalRatingChange: () => void;
 };
 
 const BookInformation: React.FC<BookInformationProps> = ({
   data,
   isbn,
+  isLogin,
   onTotalRatingChange,
 }) => {
   return (
@@ -40,12 +42,13 @@ const BookInformation: React.FC<BookInformationProps> = ({
         <div className="flex flex-row items-center mt-[30px] gap-x-[70px]">
           <BookStarRating
             isbn={isbn}
+            isLogin={isLogin}
             ratingAverage={data.ratingAverage}
             onTotalRatingChange={onTotalRatingChange}
           />
 
           <div className="w-full flex flex-row gap-x-[26px] justify-end">
-            <BookStatus isbn={isbn} />
+            <BookStatus isbn={isbn} isLogin={isLogin} />
           </div>
         </div>
         <hr className="w-full border border-[#F4E4CE] mt-[18px] mb-[32px]" />

--- a/src/app/book/_component/BookStarRating.tsx
+++ b/src/app/book/_component/BookStarRating.tsx
@@ -188,6 +188,7 @@ const BookStarRating = ({
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       )}
     </>

--- a/src/app/book/_component/BookStarRating.tsx
+++ b/src/app/book/_component/BookStarRating.tsx
@@ -1,3 +1,4 @@
+import Modal from "@/app/components/Modal/Modal";
 import BigStar from "@/assets/img/big-star.svg";
 import EmptyStar from "@/assets/img/empty-star.svg";
 import HalfStar from "@/assets/img/half-star.svg";
@@ -7,15 +8,22 @@ import { useGetStarRating } from "@/hook/reactQuery/book/useGetStarRating";
 import { usePatchStarRating } from "@/hook/reactQuery/book/usePatchStarRating";
 import { useEffect, useState } from "react";
 
-type Isbn = {
+type BookStarRatingCondition = {
   isbn: string;
+  isLogin: boolean;
   ratingAverage: number;
   onTotalRatingChange: () => void;
 };
 
-const BookStarRating = ({ isbn, ratingAverage, onTotalRatingChange }: Isbn) => {
+const BookStarRating = ({
+  isbn,
+  isLogin,
+  ratingAverage,
+  onTotalRatingChange,
+}: BookStarRatingCondition) => {
   const [starRate, setStarRate] = useState<number>(0);
   const [myStarRate, setMyStarRate] = useState<number>(0);
+  const [showModal, setShowModal] = useState<boolean>(false);
   const [evaluate, setEvaluate] = useState<string>("평가하기");
   const { data: getStarRating, refetch: refetchStarRating } =
     useGetStarRating(isbn);
@@ -36,27 +44,34 @@ const BookStarRating = ({ isbn, ratingAverage, onTotalRatingChange }: Isbn) => {
     setStarRate(index + (half ? 0.5 : 1));
   };
   const saveMyStarRate = async () => {
-    if (myStarRate === starRate) {
-      setMyStarRate(0);
-      if (getStarRating?.id) {
-        await deleteStarRating.mutateAsync(getStarRating?.id);
-        await refetchStarRating(); // 별점 삭제 후 다시 불러오기
-        onTotalRatingChange(); // 평균 별점 변경 이벤트 호출
+    if (isLogin) {
+      if (myStarRate === starRate) {
+        setMyStarRate(0);
+        if (getStarRating?.id) {
+          await deleteStarRating.mutateAsync(getStarRating?.id);
+          await refetchStarRating(); // 별점 삭제 후 다시 불러오기
+          onTotalRatingChange(); // 평균 별점 변경 이벤트 호출
+        }
+      } else {
+        setMyStarRate(starRate);
+        if (getStarRating?.id) {
+          await patchStarRating.mutateAsync({
+            bookIsbn: isbn,
+            rating: starRate,
+          });
+          await refetchStarRating(); // 별점 수정 후 다시 불러오기
+          onTotalRatingChange(); // 평균 별점 변경 이벤트 호출
+        } else {
+          await createStarRating.mutateAsync({
+            bookIsbn: isbn,
+            rating: starRate,
+          });
+          await refetchStarRating(); // 별점 생성 후 다시 불러오기
+          onTotalRatingChange(); // 평균 별점 변경 이벤트 호출
+        }
       }
     } else {
-      setMyStarRate(starRate);
-      if (getStarRating?.id) {
-        await patchStarRating.mutateAsync({ bookIsbn: isbn, rating: starRate });
-        await refetchStarRating(); // 별점 수정 후 다시 불러오기
-        onTotalRatingChange(); // 평균 별점 변경 이벤트 호출
-      } else {
-        await createStarRating.mutateAsync({
-          bookIsbn: isbn,
-          rating: starRate,
-        });
-        await refetchStarRating(); // 별점 생성 후 다시 불러오기
-        onTotalRatingChange(); // 평균 별점 변경 이벤트 호출
-      }
+      setShowModal(!showModal);
     }
   };
 
@@ -118,6 +133,11 @@ const BookStarRating = ({ isbn, ratingAverage, onTotalRatingChange }: Isbn) => {
       return <EmptyStar />;
     }
   };
+
+  const closeModal = () => {
+    setShowModal(false);
+  };
+
   return (
     <>
       <div className="flex flex-col">
@@ -161,6 +181,15 @@ const BookStarRating = ({ isbn, ratingAverage, onTotalRatingChange }: Isbn) => {
         </div>
         <div className="text-base text-[#B1B1B1]">평균별점</div>
       </div>
+      {!isLogin && (
+        <Modal
+          title="로그인"
+          content="로그인을 해야 이용할 수 있는 기능입니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      )}
     </>
   );
 };

--- a/src/app/book/_component/BookStatus.tsx
+++ b/src/app/book/_component/BookStatus.tsx
@@ -107,6 +107,7 @@ const BookStatus: React.FC<BookStatusCondition> = ({ isbn, isLogin }) => {
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       )}
     </>

--- a/src/app/book/_component/registerEvaluation.tsx
+++ b/src/app/book/_component/registerEvaluation.tsx
@@ -1,18 +1,30 @@
 import { Button } from "@/app/components/Button/Button";
+import Modal from "@/app/components/Modal/Modal";
 import { Textarea } from "@/app/components/Textarea/Textarea";
 import { useCreateReview } from "@/hook/reactQuery/book/useCreateReview";
 import { useInput } from "@/hook/useInput";
+import { useState } from "react";
 
-type Isbn = {
+type RegisterCondition = {
   isbn: string;
+  isLogin: boolean;
 };
 
-const registerEvaluation = ({ isbn }: Isbn) => {
+const registerEvaluation = ({ isbn, isLogin }: RegisterCondition) => {
   const { value: review, handleChange: onCreateReview } = useInput("");
   const createReview = useCreateReview();
+  const [showModal, setShowModal] = useState<boolean>(false);
 
   const handleReviewSubmit = () => {
-    createReview.mutate({ bookIsbn: isbn, content: review });
+    if (isLogin) {
+      createReview.mutate({ bookIsbn: isbn, content: review });
+    } else {
+      setShowModal(!showModal);
+    }
+  };
+
+  const closeModal = () => {
+    setShowModal(false);
   };
 
   return (
@@ -37,6 +49,15 @@ const registerEvaluation = ({ isbn }: Isbn) => {
           </Button>
         </div>
       </div>
+      {!isLogin && (
+        <Modal
+          title="로그인"
+          content="로그인을 해야 이용할 수 있는 기능입니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      )}
     </>
   );
 };

--- a/src/app/book/_component/registerEvaluation.tsx
+++ b/src/app/book/_component/registerEvaluation.tsx
@@ -64,6 +64,7 @@ const registerEvaluation = ({ isbn, isLogin }: RegisterCondition) => {
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       ) : review.length > 0 ? (
         <Modal
@@ -72,6 +73,7 @@ const registerEvaluation = ({ isbn, isLogin }: RegisterCondition) => {
           isOpen={showModal}
           onClose={refreshPage}
           onConfirm={refreshPage}
+          buttonTitle="확인"
         />
       ) : (
         <Modal
@@ -80,6 +82,7 @@ const registerEvaluation = ({ isbn, isLogin }: RegisterCondition) => {
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       )}
     </>

--- a/src/app/book/_component/registerEvaluation.tsx
+++ b/src/app/book/_component/registerEvaluation.tsx
@@ -17,7 +17,10 @@ const registerEvaluation = ({ isbn, isLogin }: RegisterCondition) => {
 
   const handleReviewSubmit = () => {
     if (isLogin) {
-      createReview.mutate({ bookIsbn: isbn, content: review });
+      if (review.length > 0) {
+        createReview.mutate({ bookIsbn: isbn, content: review });
+      }
+      setShowModal(!showModal);
     } else {
       setShowModal(!showModal);
     }
@@ -25,6 +28,11 @@ const registerEvaluation = ({ isbn, isLogin }: RegisterCondition) => {
 
   const closeModal = () => {
     setShowModal(false);
+  };
+
+  const refreshPage = () => {
+    setShowModal(false);
+    window.location.reload();
   };
 
   return (
@@ -49,10 +57,26 @@ const registerEvaluation = ({ isbn, isLogin }: RegisterCondition) => {
           </Button>
         </div>
       </div>
-      {!isLogin && (
+      {!isLogin ? (
         <Modal
           title="로그인"
           content="로그인을 해야 이용할 수 있는 기능입니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      ) : review.length > 0 ? (
+        <Modal
+          title="한줄평 작성 완료"
+          content="한줄평이 등록되었습니다"
+          isOpen={showModal}
+          onClose={refreshPage}
+          onConfirm={refreshPage}
+        />
+      ) : (
+        <Modal
+          title="한줄평"
+          content="한줄평을 적어주세요"
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,5 +1,16 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
 const page = () => {
-  return <>book</>;
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace("/not-found");
+  }, [router]);
+
+  return null;
 };
 
 export default page;

--- a/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
@@ -7,6 +7,7 @@ import { useDeleteReview } from "@/hook/reactQuery/book/useDeleteReview";
 import { useDeleteReviewLike } from "@/hook/reactQuery/book/useDeleteReviewLike";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import DeleteButton from "../../DeleteButton/DeleteButton";
 import IconButton from "../../IconButton/IconButton";
 import LikeButton from "../../LikeButton/LikeButton";
 import Modal from "../../Modal/Modal";
@@ -131,12 +132,7 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
           </div>
           <div>
             {data.creatorId === userId && (
-              <div
-                className="flex items-center justify-center text-[21px] text-[#656565] px-[10px] border-[#D9D9D9] border border-solid rounded-[3px] bg-[#FFF] hover:bg-[#FBFBFB] hover:border-[#80685D] cursor-pointer"
-                onClick={closeDeleteShowModal}
-              >
-                삭제
-              </div>
+              <DeleteButton onClick={closeDeleteShowModal} />
             )}
           </div>
         </div>

--- a/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
@@ -3,6 +3,7 @@ import NotLike from "@/assets/img/not-like.svg";
 import Profile from "@/assets/img/profile.png";
 import Star from "@/assets/img/star.svg";
 import { useCreateReviewLike } from "@/hook/reactQuery/book/useCreateReviewLike";
+import { useDeleteReview } from "@/hook/reactQuery/book/useDeleteReview";
 import { useDeleteReviewLike } from "@/hook/reactQuery/book/useDeleteReviewLike";
 import Image from "next/image";
 import { useEffect, useState } from "react";
@@ -34,7 +35,9 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
   const [isLike, setIsLike] = useState<boolean>(initialIsLike);
   const createReviewLike = useCreateReviewLike();
   const deleteReviewLike = useDeleteReviewLike();
+  const deleteReview = useDeleteReview();
   const [showModal, setShowModal] = useState<boolean>(false);
+  const [deleteShowModal, setDeleteShowModal] = useState<boolean>(false);
 
   useEffect(() => {
     setCount(data.likeCount);
@@ -60,6 +63,18 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
 
   const closeModal = () => {
     setShowModal(false);
+  };
+
+  const deleteMyReview = () => {
+    deleteReview.mutate(data.reviewId, {
+      onSuccess: () => {
+        window.location.reload();
+      },
+    });
+  };
+
+  const closeDeleteShowModal = () => {
+    setDeleteShowModal(!deleteShowModal);
   };
 
   return (
@@ -110,8 +125,20 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
 
         <hr className="w-full border border-[#F4E4CE] mt-[8px] mb-[16px]" />
 
-        <div className="flex justify-start mb-[19px]">
-          <LikeButton isLike={isLike} onClick={changeIsLike} />
+        <div className="flex">
+          <div className="flex grow justify-start mb-[19px]">
+            <LikeButton isLike={isLike} onClick={changeIsLike} />
+          </div>
+          <div>
+            {data.creatorId === userId && (
+              <div
+                className="flex items-center justify-center text-[21px] text-[#656565] px-[10px] border-[#D9D9D9] border border-solid rounded-[3px] bg-[#FFF] hover:bg-[#FBFBFB] hover:border-[#80685D] cursor-pointer"
+                onClick={closeDeleteShowModal}
+              >
+                삭제
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
@@ -132,6 +159,13 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
           onConfirm={closeModal}
         />
       )}
+      <Modal
+        title="한줄평 삭제"
+        content="한줄평을 삭제하시겠습니까?"
+        isOpen={deleteShowModal}
+        onClose={closeDeleteShowModal}
+        onConfirm={deleteMyReview}
+      />
     </div>
   );
 };

--- a/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
@@ -20,11 +20,13 @@ type UserEvaluation = {
     starRating: number;
     likeCount: number;
   };
+  userId: number;
   isLike: boolean;
 };
 
 const EvaluationCard: React.FC<UserEvaluation> = ({
   data,
+  userId,
   isLike: initialIsLike,
 }) => {
   const [count, setCount] = useState<number>(data.likeCount);
@@ -38,14 +40,18 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
   }, [data.likeCount, initialIsLike]);
 
   const changeIsLike = () => {
-    if (isLike) {
-      deleteReviewLike.mutate(data.reviewId);
-      setCount((prevCount) => prevCount - 1);
+    if (data.creatorId !== userId) {
+      if (isLike) {
+        deleteReviewLike.mutate(data.reviewId);
+        setCount((prevCount) => prevCount - 1);
+      } else {
+        createReviewLike.mutate(data.reviewId);
+        setCount((prevCount) => prevCount + 1);
+      }
+      setIsLike(!isLike);
     } else {
-      createReviewLike.mutate(data.reviewId);
-      setCount((prevCount) => prevCount + 1);
+      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
     }
-    setIsLike(!isLike);
   };
   return (
     <div className="w-[910px] min-h-[320px] bg-[#FFF] rounded-[18px] mb-[30px] border border-[#F4E4CE] font-Pretendard font-medium">

--- a/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
@@ -145,6 +145,7 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       ) : (
         <Modal
@@ -153,6 +154,7 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       )}
       <Modal
@@ -161,6 +163,7 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
         isOpen={deleteShowModal}
         onClose={closeDeleteShowModal}
         onConfirm={deleteMyReview}
+        buttonTitle="삭제"
       />
     </div>
   );

--- a/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
@@ -8,6 +8,7 @@ import Image from "next/image";
 import { useEffect, useState } from "react";
 import IconButton from "../../IconButton/IconButton";
 import LikeButton from "../../LikeButton/LikeButton";
+import Modal from "../../Modal/Modal";
 
 type UserEvaluation = {
   data: {
@@ -33,6 +34,7 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
   const [isLike, setIsLike] = useState<boolean>(initialIsLike);
   const createReviewLike = useCreateReviewLike();
   const deleteReviewLike = useDeleteReviewLike();
+  const [showModal, setShowModal] = useState<boolean>(false);
 
   useEffect(() => {
     setCount(data.likeCount);
@@ -40,7 +42,9 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
   }, [data.likeCount, initialIsLike]);
 
   const changeIsLike = () => {
-    if (data.creatorId !== userId) {
+    if (userId === -1) {
+      setShowModal(!showModal);
+    } else if (data.creatorId !== userId) {
       if (isLike) {
         deleteReviewLike.mutate(data.reviewId);
         setCount((prevCount) => prevCount - 1);
@@ -50,9 +54,14 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
       }
       setIsLike(!isLike);
     } else {
-      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
+      setShowModal(!showModal);
     }
   };
+
+  const closeModal = () => {
+    setShowModal(false);
+  };
+
   return (
     <div className="w-[910px] min-h-[320px] bg-[#FFF] rounded-[18px] mb-[30px] border border-[#F4E4CE] font-Pretendard font-medium">
       <div className="mt-[20px] ml-[30px] mr-[26px] w-auto">
@@ -105,6 +114,24 @@ const EvaluationCard: React.FC<UserEvaluation> = ({
           <LikeButton isLike={isLike} onClick={changeIsLike} />
         </div>
       </div>
+
+      {userId === -1 ? (
+        <Modal
+          title="로그인"
+          content="로그인을 해야 이용할 수 있는 기능입니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      ) : (
+        <Modal
+          title="좋아요 실패"
+          content="본인이 작성한 평가에는 좋아요를 할 수 없습니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      )}
     </div>
   );
 };

--- a/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/EvaluationCard.tsx
@@ -13,6 +13,7 @@ type UserEvaluation = {
   data: {
     reviewId: number;
     ratingId: number;
+    creatorId: number;
     username: string;
     profileImage: string;
     reviewContent: string;

--- a/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
@@ -20,11 +20,13 @@ type MiniEvaluationProps = {
     starRating: number;
     likeCount: number;
   };
+  userId: number;
   isLike: boolean;
 };
 
 const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
   data,
+  userId,
   isLike: initialIsLike,
 }) => {
   const [count, setCount] = useState<number>(data.likeCount);
@@ -38,14 +40,18 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
   }, [data.likeCount, initialIsLike]);
 
   const changeIsLike = () => {
-    if (isLike) {
-      deleteReviewLike.mutate(data.reviewId);
-      setCount((prevCount) => prevCount - 1);
+    if (data.creatorId !== userId) {
+      if (isLike) {
+        deleteReviewLike.mutate(data.reviewId);
+        setCount((prevCount) => prevCount - 1);
+      } else {
+        createReviewLike.mutate(data.reviewId);
+        setCount((prevCount) => prevCount + 1);
+      }
+      setIsLike(!isLike);
     } else {
-      createReviewLike.mutate(data.reviewId);
-      setCount((prevCount) => prevCount + 1);
+      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
     }
-    setIsLike(!isLike);
   };
   return (
     <div className="w-[405px] max-h-[279px] bg-[#FFF] border border-[#F4E4CE] mb-[30px] rounded-[11px] font-Pretendard font-medium">

--- a/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
@@ -126,8 +126,9 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
         </div>
 
         <hr className="w-full border border-[#F4E4CE] mt-[5px] mb-[10px]" />
+
         <div className="flex">
-          <div className="flex justify-start mb-[11px] grow">
+          <div className="flex grow justify-start mb-[11px]">
             <LikeButton isLike={isLike} onClick={changeIsLike} />
           </div>
           <div>

--- a/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
@@ -3,6 +3,7 @@ import NotLike from "@/assets/img/not-like.svg";
 import Profile from "@/assets/img/profile.png";
 import Star from "@/assets/img/star.svg";
 import { useCreateReviewLike } from "@/hook/reactQuery/book/useCreateReviewLike";
+import { useDeleteReview } from "@/hook/reactQuery/book/useDeleteReview";
 import { useDeleteReviewLike } from "@/hook/reactQuery/book/useDeleteReviewLike";
 import Image from "next/image";
 import { useEffect, useState } from "react";
@@ -34,7 +35,9 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
   const [isLike, setIsLike] = useState<boolean>(initialIsLike);
   const createReviewLike = useCreateReviewLike();
   const deleteReviewLike = useDeleteReviewLike();
+  const deleteReview = useDeleteReview();
   const [showModal, setShowModal] = useState<boolean>(false);
+  const [deleteShowModal, setDeleteShowModal] = useState<boolean>(false);
 
   useEffect(() => {
     setCount(data.likeCount);
@@ -60,6 +63,18 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
 
   const closeModal = () => {
     setShowModal(false);
+  };
+
+  const deleteMyReview = () => {
+    deleteReview.mutate(data.reviewId, {
+      onSuccess: () => {
+        window.location.reload();
+      },
+    });
+  };
+
+  const closeDeleteShowModal = () => {
+    setDeleteShowModal(!deleteShowModal);
   };
 
   return (
@@ -111,9 +126,20 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
         </div>
 
         <hr className="w-full border border-[#F4E4CE] mt-[5px] mb-[10px]" />
-
-        <div className="flex justify-start mb-[11px]">
-          <LikeButton isLike={isLike} onClick={changeIsLike} />
+        <div className="flex">
+          <div className="flex justify-start mb-[11px] grow">
+            <LikeButton isLike={isLike} onClick={changeIsLike} />
+          </div>
+          <div>
+            {data.creatorId === userId && (
+              <div
+                className="flex items-center justify-center text-[21px] text-[#656565] px-[10px] border-[#D9D9D9] border border-solid rounded-[3px] bg-[#FFF] hover:bg-[#FBFBFB] hover:border-[#80685D] cursor-pointer"
+                onClick={closeDeleteShowModal}
+              >
+                삭제
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
@@ -134,6 +160,13 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
           onConfirm={closeModal}
         />
       )}
+      <Modal
+        title="한줄평 삭제"
+        content="한줄평을 삭제하시겠습니까?"
+        isOpen={deleteShowModal}
+        onClose={closeDeleteShowModal}
+        onConfirm={deleteMyReview}
+      />
     </div>
   );
 };

--- a/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
@@ -8,6 +8,7 @@ import Image from "next/image";
 import { useEffect, useState } from "react";
 import IconButton from "../../IconButton/IconButton";
 import LikeButton from "../../LikeButton/LikeButton";
+import Modal from "../../Modal/Modal";
 
 type MiniEvaluationProps = {
   data: {
@@ -33,6 +34,7 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
   const [isLike, setIsLike] = useState<boolean>(initialIsLike);
   const createReviewLike = useCreateReviewLike();
   const deleteReviewLike = useDeleteReviewLike();
+  const [showModal, setShowModal] = useState<boolean>(false);
 
   useEffect(() => {
     setCount(data.likeCount);
@@ -40,7 +42,9 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
   }, [data.likeCount, initialIsLike]);
 
   const changeIsLike = () => {
-    if (data.creatorId !== userId) {
+    if (userId === -1) {
+      setShowModal(!showModal);
+    } else if (data.creatorId !== userId) {
       if (isLike) {
         deleteReviewLike.mutate(data.reviewId);
         setCount((prevCount) => prevCount - 1);
@@ -50,9 +54,14 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
       }
       setIsLike(!isLike);
     } else {
-      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
+      setShowModal(!showModal);
     }
   };
+
+  const closeModal = () => {
+    setShowModal(false);
+  };
+
   return (
     <div className="w-[405px] max-h-[279px] bg-[#FFF] border border-[#F4E4CE] mb-[30px] rounded-[11px] font-Pretendard font-medium">
       <div className="mt-[18px] ml-[15px] mr-[13px] w-auto">
@@ -107,6 +116,24 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
           <LikeButton isLike={isLike} onClick={changeIsLike} />
         </div>
       </div>
+
+      {userId === -1 ? (
+        <Modal
+          title="로그인"
+          content="로그인을 해야 이용할 수 있는 기능입니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      ) : (
+        <Modal
+          title="좋아요 실패"
+          content="본인이 작성한 평가에는 좋아요를 할 수 없습니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      )}
     </div>
   );
 };

--- a/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
@@ -13,6 +13,7 @@ type MiniEvaluationProps = {
   data: {
     reviewId: number;
     ratingId: number;
+    creatorId: number;
     username: string;
     profileImage: string;
     reviewContent: string;

--- a/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
@@ -7,6 +7,7 @@ import { useDeleteReview } from "@/hook/reactQuery/book/useDeleteReview";
 import { useDeleteReviewLike } from "@/hook/reactQuery/book/useDeleteReviewLike";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import DeleteButton from "../../DeleteButton/DeleteButton";
 import IconButton from "../../IconButton/IconButton";
 import LikeButton from "../../LikeButton/LikeButton";
 import Modal from "../../Modal/Modal";
@@ -133,12 +134,7 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
           </div>
           <div>
             {data.creatorId === userId && (
-              <div
-                className="flex items-center justify-center text-[21px] text-[#656565] px-[10px] border-[#D9D9D9] border border-solid rounded-[3px] bg-[#FFF] hover:bg-[#FBFBFB] hover:border-[#80685D] cursor-pointer"
-                onClick={closeDeleteShowModal}
-              >
-                삭제
-              </div>
+              <DeleteButton onClick={closeDeleteShowModal} />
             )}
           </div>
         </div>

--- a/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
+++ b/src/app/components/Card/EvaluationCard/MiniEvaluationCard.tsx
@@ -147,6 +147,7 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       ) : (
         <Modal
@@ -155,6 +156,7 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       )}
       <Modal
@@ -163,6 +165,7 @@ const MiniEvaluationCard: React.FC<MiniEvaluationProps> = ({
         isOpen={deleteShowModal}
         onClose={closeDeleteShowModal}
         onConfirm={deleteMyReview}
+        buttonTitle="삭제"
       />
     </div>
   );

--- a/src/app/components/Card/MainPageCard/RelatedTalkRoomCard.tsx
+++ b/src/app/components/Card/MainPageCard/RelatedTalkRoomCard.tsx
@@ -26,11 +26,13 @@ type TalkRoomCardProps = {
     registeredDateTime?: string;
     creatorId: number;
   };
+  userId: number;
   isLike: boolean;
 };
 
 const RelatedTalkRoomCard: React.FC<TalkRoomCardProps> = ({
   data,
+  userId,
   isLike: initialIsLike,
 }) => {
   const [count, setCount] = useState<number>(data.likeCount);
@@ -45,14 +47,18 @@ const RelatedTalkRoomCard: React.FC<TalkRoomCardProps> = ({
 
   const changeIsLike = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    if (isLike) {
-      deleteTalkRoomLike.mutate(data.id);
-      setCount((prevCount) => prevCount - 1);
+    if (data.creatorId !== userId) {
+      if (isLike) {
+        deleteTalkRoomLike.mutate(data.id);
+        setCount((prevCount) => prevCount - 1);
+      } else {
+        addTalkRoomLike.mutate(data.id);
+        setCount((prevCount) => prevCount + 1);
+      }
+      setIsLike(!isLike);
     } else {
-      addTalkRoomLike.mutate(data.id);
-      setCount((prevCount) => prevCount + 1);
+      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
     }
-    setIsLike(!isLike);
   };
   return (
     <Link href={`/talkroom/detail/${data.id}`}>

--- a/src/app/components/Card/MainPageCard/RelatedTalkRoomCard.tsx
+++ b/src/app/components/Card/MainPageCard/RelatedTalkRoomCard.tsx
@@ -24,6 +24,7 @@ type TalkRoomCardProps = {
     likeCount: number;
     readingStatuses: string[];
     registeredDateTime?: string;
+    creatorId: number;
   };
   isLike: boolean;
 };

--- a/src/app/components/Card/MainPageCard/RelatedTalkRoomCard.tsx
+++ b/src/app/components/Card/MainPageCard/RelatedTalkRoomCard.tsx
@@ -10,6 +10,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import IconButton from "../../IconButton/IconButton";
+import Modal from "../../Modal/Modal";
 
 type TalkRoomCardProps = {
   data: {
@@ -39,6 +40,7 @@ const RelatedTalkRoomCard: React.FC<TalkRoomCardProps> = ({
   const [isLike, setIsLike] = useState<boolean>(initialIsLike);
   const addTalkRoomLike = useCreateRoomLike();
   const deleteTalkRoomLike = useDeleteRoomLike();
+  const [showModal, setShowModal] = useState<boolean>(false);
 
   useEffect(() => {
     setCount(data.likeCount);
@@ -47,7 +49,9 @@ const RelatedTalkRoomCard: React.FC<TalkRoomCardProps> = ({
 
   const changeIsLike = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    if (data.creatorId !== userId) {
+    if (userId === -1) {
+      setShowModal(!showModal);
+    } else if (data.creatorId !== userId) {
       if (isLike) {
         deleteTalkRoomLike.mutate(data.id);
         setCount((prevCount) => prevCount - 1);
@@ -57,12 +61,17 @@ const RelatedTalkRoomCard: React.FC<TalkRoomCardProps> = ({
       }
       setIsLike(!isLike);
     } else {
-      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
+      setShowModal(!showModal);
     }
   };
+
+  const closeModal = () => {
+    setShowModal(false);
+  };
+
   return (
-    <Link href={`/talkroom/detail/${data.id}`}>
-      <div className="relative w-[547px] h-[426px] rounded-[17px] bg-[#fff] border rounded-[17px] border-[#F4E4CE] font-Pretendard overflow-hidden">
+    <div className="relative w-[547px] h-[426px] rounded-[17px] bg-[#fff] border rounded-[17px] border-[#F4E4CE] font-Pretendard overflow-hidden">
+      <Link href={`/talkroom/detail/${data.id}`}>
         <div className="absolute inset-0 transform -skew-y-[10deg] h-[200px] bg-[#80685D] top-[-15%]"></div>
         <div className="absolute inset-0 flex justify-center items-center">
           <div className="flex flex-col mx-8 mt-[31px] mb-3 w-full">
@@ -134,8 +143,26 @@ const RelatedTalkRoomCard: React.FC<TalkRoomCardProps> = ({
             </div>
           </div>
         </div>
-      </div>
-    </Link>
+      </Link>
+
+      {userId === -1 ? (
+        <Modal
+          title="로그인"
+          content="로그인을 해야 이용할 수 있는 기능입니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      ) : (
+        <Modal
+          title="좋아요 실패"
+          content="본인이 작성한 토크방에는 좋아요를 할 수 없습니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      )}
+    </div>
   );
 };
 

--- a/src/app/components/Card/MainPageCard/RelatedTalkRoomCard.tsx
+++ b/src/app/components/Card/MainPageCard/RelatedTalkRoomCard.tsx
@@ -152,6 +152,7 @@ const RelatedTalkRoomCard: React.FC<TalkRoomCardProps> = ({
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       ) : (
         <Modal
@@ -160,6 +161,7 @@ const RelatedTalkRoomCard: React.FC<TalkRoomCardProps> = ({
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       )}
     </div>

--- a/src/app/components/Card/MainPageCard/TalkRoomCard.tsx
+++ b/src/app/components/Card/MainPageCard/TalkRoomCard.tsx
@@ -26,12 +26,14 @@ type TalkRoomCardProps = {
     registeredDateTime?: string;
     creatorId: number;
   };
+  userId: number;
   isBest: boolean;
   isLike: boolean;
 };
 
 const TalkRoomCard: React.FC<TalkRoomCardProps> = ({
   data,
+  userId,
   isBest,
   isLike: initialIsLike,
 }) => {
@@ -47,14 +49,18 @@ const TalkRoomCard: React.FC<TalkRoomCardProps> = ({
 
   const changeIsLike = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    if (isLike) {
-      deleteTalkRoomLike.mutate(data.id);
-      setCount((prevCount) => prevCount - 1);
+    if (data.creatorId !== userId) {
+      if (isLike) {
+        deleteTalkRoomLike.mutate(data.id);
+        setCount((prevCount) => prevCount - 1);
+      } else {
+        addTalkRoomLike.mutate(data.id);
+        setCount((prevCount) => prevCount + 1);
+      }
+      setIsLike(!isLike);
     } else {
-      addTalkRoomLike.mutate(data.id);
-      setCount((prevCount) => prevCount + 1);
+      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
     }
-    setIsLike(!isLike);
   };
   return (
     <div

--- a/src/app/components/Card/MainPageCard/TalkRoomCard.tsx
+++ b/src/app/components/Card/MainPageCard/TalkRoomCard.tsx
@@ -24,6 +24,7 @@ type TalkRoomCardProps = {
     likeCount: number;
     readingStatuses?: string[];
     registeredDateTime?: string;
+    creatorId: number;
   };
   isBest: boolean;
   isLike: boolean;

--- a/src/app/components/Card/MainPageCard/TalkRoomCard.tsx
+++ b/src/app/components/Card/MainPageCard/TalkRoomCard.tsx
@@ -365,6 +365,7 @@ const TalkRoomCard: React.FC<TalkRoomCardProps> = ({
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       ) : (
         <Modal
@@ -373,6 +374,7 @@ const TalkRoomCard: React.FC<TalkRoomCardProps> = ({
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       )}
     </div>

--- a/src/app/components/Card/MainPageCard/TalkRoomCard.tsx
+++ b/src/app/components/Card/MainPageCard/TalkRoomCard.tsx
@@ -10,6 +10,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import IconButton from "../../IconButton/IconButton";
+import Modal from "../../Modal/Modal";
 
 type TalkRoomCardProps = {
   data: {
@@ -41,6 +42,7 @@ const TalkRoomCard: React.FC<TalkRoomCardProps> = ({
   const [isLike, setIsLike] = useState<boolean>(initialIsLike);
   const addTalkRoomLike = useCreateRoomLike();
   const deleteTalkRoomLike = useDeleteRoomLike();
+  const [showModal, setShowModal] = useState<boolean>(false);
 
   useEffect(() => {
     setCount(data.likeCount);
@@ -49,7 +51,9 @@ const TalkRoomCard: React.FC<TalkRoomCardProps> = ({
 
   const changeIsLike = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    if (data.creatorId !== userId) {
+    if (userId === -1) {
+      setShowModal(!showModal);
+    } else if (data.creatorId !== userId) {
       if (isLike) {
         deleteTalkRoomLike.mutate(data.id);
         setCount((prevCount) => prevCount - 1);
@@ -59,9 +63,14 @@ const TalkRoomCard: React.FC<TalkRoomCardProps> = ({
       }
       setIsLike(!isLike);
     } else {
-      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
+      setShowModal(!showModal);
     }
   };
+
+  const closeModal = () => {
+    setShowModal(false);
+  };
+
   return (
     <div
       className="relative 
@@ -348,6 +357,24 @@ const TalkRoomCard: React.FC<TalkRoomCardProps> = ({
           </div>
         </div>
       </Link>
+
+      {userId === -1 ? (
+        <Modal
+          title="로그인"
+          content="로그인을 해야 이용할 수 있는 기능입니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      ) : (
+        <Modal
+          title="좋아요 실패"
+          content="본인이 작성한 토크방에는 좋아요를 할 수 없습니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      )}
     </div>
   );
 };

--- a/src/app/components/DeleteButton/DeleteButton.tsx
+++ b/src/app/components/DeleteButton/DeleteButton.tsx
@@ -1,0 +1,16 @@
+type DeleteFunction = {
+  onClick: () => void;
+};
+
+const DeleteButton = ({ onClick }: DeleteFunction) => {
+  return (
+    <div
+      className="flex items-center justify-center text-[21px] text-[#656565] px-[10px] border-[#D9D9D9] border border-solid rounded-[3px] bg-[#FFF] hover:bg-[#FBFBFB] hover:border-[#80685D] cursor-pointer"
+      onClick={onClick}
+    >
+      삭제
+    </div>
+  );
+};
+
+export default DeleteButton;

--- a/src/app/components/LikeButton/LikeButton.tsx
+++ b/src/app/components/LikeButton/LikeButton.tsx
@@ -10,7 +10,7 @@ const LikeButton = ({ isLike, onClick }: LikeButtonProps) => {
     </div>
   ) : (
     <div
-      className="flex items-center justify-center font-Pretendard font-medium text-[21px] text-[#656565] px-[10px] border-[#D9D9D9] border border-solid rounded-[3px] bg-[#FFF] hover:bg-[#FBFBFB] cursor-pointer"
+      className="flex items-center justify-center font-Pretendard font-medium text-[21px] text-[#656565] px-[10px] border-[#D9D9D9] border border-solid rounded-[3px] bg-[#FFF] hover:bg-[#FBFBFB] hover:border-[#80685D] cursor-pointer"
       onClick={onClick}
     >
       좋아요

--- a/src/app/components/Modal/Modal.tsx
+++ b/src/app/components/Modal/Modal.tsx
@@ -7,6 +7,7 @@ interface ModalProps {
   onClose: () => void;
   onConfirm: () => void;
   isOpen: boolean;
+  buttonTitle: string;
 }
 
 const Modal: React.FC<ModalProps> = ({
@@ -15,6 +16,7 @@ const Modal: React.FC<ModalProps> = ({
   onClose,
   onConfirm,
   isOpen,
+  buttonTitle,
 }) => {
   if (!isOpen) return null;
 
@@ -35,7 +37,7 @@ const Modal: React.FC<ModalProps> = ({
         </div>
         <div className="flex">
           <Button onClick={onConfirm} rounded="none">
-            확인
+            {buttonTitle}
           </Button>
         </div>
       </div>

--- a/src/app/components/ModifyButton/ModifyButton.tsx
+++ b/src/app/components/ModifyButton/ModifyButton.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+type Href = {
+  href: string;
+};
+
+const ModifyButton = ({ href }: Href) => {
+  return (
+    <Link href={href}>
+      <div className="flex items-center justify-center text-[21px] text-[#656565] px-[10px] border-[#D9D9D9] border border-solid rounded-[3px] bg-[#FFF] hover:bg-[#FBFBFB] hover:border-[#80685D] cursor-pointer">
+        수정
+      </div>
+    </Link>
+  );
+};
+
+export default ModifyButton;

--- a/src/app/components/Swiper/TalkRoomCardSwiper.tsx
+++ b/src/app/components/Swiper/TalkRoomCardSwiper.tsx
@@ -15,16 +15,19 @@ type TalkRoom = {
   likeCount: number;
   readingStatuses: string[];
   registeredDateTime: string;
+  creatorId: number;
 };
 
 type Props = {
   talkRooms: TalkRoom[];
+  userId: number;
   userLikeTalkRoomIds: number[];
   isBest: boolean;
 };
 
 const TalkRoomCardSwiper = ({
   talkRooms,
+  userId,
   userLikeTalkRoomIds,
   isBest,
 }: Props) => {
@@ -66,7 +69,12 @@ const TalkRoomCardSwiper = ({
         const isLike = userLikeTalkRoomIds.includes(data.id);
         return (
           <SwiperSlide key={data.id}>
-            <TalkRoomCard data={data} isBest={isBest} isLike={isLike} />
+            <TalkRoomCard
+              data={data}
+              userId={userId}
+              isBest={isBest}
+              isLike={isLike}
+            />
           </SwiperSlide>
         );
       })}

--- a/src/app/evaluation/[isbn]/page.tsx
+++ b/src/app/evaluation/[isbn]/page.tsx
@@ -18,6 +18,7 @@ import MainThemeTitle from "../../components/MainThemeTitle/MainThemeTitle";
 type UserEvaluation = {
   reviewId: number;
   ratingId: number;
+  creatorId: number;
   username: string;
   profileImage: string;
   reviewContent: string;

--- a/src/app/evaluation/[isbn]/page.tsx
+++ b/src/app/evaluation/[isbn]/page.tsx
@@ -8,6 +8,7 @@ import UserEvaluationImg from "@/assets/img/user-evaluation.svg";
 import { useGetBookInformation } from "@/hook/reactQuery/book/useGetBookInformation";
 import { useGetReview } from "@/hook/reactQuery/book/useGetReview";
 import { useGetReviewLike } from "@/hook/reactQuery/book/useGetReviewLike";
+import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
 import { useLogin } from "@/hook/useLogin";
 import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -34,6 +35,9 @@ const page = ({ params }: { params: { isbn: string } }) => {
   const { data: reviewLikeIds } = isLoggedIn
     ? useGetReviewLike()
     : { data: { reviewIds: [] } };
+  const { data: myDetailData } = isLoggedIn
+    ? useGetMyDetail()
+    : { data: { userId: -1, userImage: "", userName: "" } };
   const { data: bookDetailData } = useGetBookInformation({
     isbn: params.isbn,
   });
@@ -114,7 +118,12 @@ const page = ({ params }: { params: { isbn: string } }) => {
               isLoggedIn &&
               (reviewLikeIds?.reviewIds || []).includes(data.reviewId);
             return (
-              <EvaluationCard key={data.reviewId} data={data} isLike={isLike} />
+              <EvaluationCard
+                key={data.reviewId}
+                data={data}
+                userId={myDetailData?.userId || -1}
+                isLike={isLike}
+              />
             );
           })}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,6 +29,7 @@ type TalkRoom = {
   likeCount: number;
   readingStatuses: string[];
   registeredDateTime: string;
+  creatorId: number;
 };
 type TalkRoomBookOrder = {
   isbn: string;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import ManyTalkRoomBook from "@/assets/img/many-talk-room-book.svg";
 import PopularTalkRoom from "@/assets/img/popular-talk-room.svg";
 import RecentTalkRoom from "@/assets/img/recent-make-talk-room.svg";
 import { useGetBookRank } from "@/hook/reactQuery/book/useGetBookRank";
+import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
 import { useGetRoomBookOrder } from "@/hook/reactQuery/talkRoom/useGetRoomBookOrder";
 import { useGetRoomLike } from "@/hook/reactQuery/talkRoom/useGetRoomLike";
 import { useGetRooms } from "@/hook/reactQuery/talkRoom/useGetRooms";
@@ -45,6 +46,9 @@ const page = () => {
   const { data: talkRoomLikeIds } = isLoggedIn
     ? useGetRoomLike()
     : { data: { talkRoomIds: [] } };
+  const { data: myDetailData } = isLoggedIn
+    ? useGetMyDetail()
+    : { data: { userId: -1, userImage: "", userName: "" } };
 
   useEffect(() => {
     const handleResize = () => {
@@ -79,6 +83,7 @@ const page = () => {
     size: 12,
     order: "comment",
   });
+
   return (
     <div className="bg-[#FFF] w-full">
       <div
@@ -129,6 +134,7 @@ const page = () => {
           isSwiper ? (
             <TalkRoomCardSwiper
               talkRooms={popularData.queryResponse}
+              userId={myDetailData?.userId || -1}
               isBest={true}
               userLikeTalkRoomIds={talkRoomLikeIds?.talkRoomIds || []}
             />
@@ -142,6 +148,7 @@ const page = () => {
                   <TalkRoomCard
                     key={data.id}
                     data={data}
+                    userId={myDetailData?.userId || -1}
                     isBest={true}
                     isLike={isLike}
                   />
@@ -232,6 +239,7 @@ const page = () => {
           isSwiper ? (
             <TalkRoomCardSwiper
               talkRooms={recentData.queryResponse}
+              userId={myDetailData?.userId || -1}
               isBest={false}
               userLikeTalkRoomIds={talkRoomLikeIds?.talkRoomIds || []}
             />
@@ -245,6 +253,7 @@ const page = () => {
                   <TalkRoomCard
                     key={data.id}
                     data={data}
+                    userId={myDetailData?.userId || -1}
                     isBest={false}
                     isLike={isLike}
                   />

--- a/src/app/search/[word]/_component/RoomCards.tsx
+++ b/src/app/search/[word]/_component/RoomCards.tsx
@@ -2,6 +2,7 @@
 
 import TalkRoomCard from "@/app/components/Card/MainPageCard/TalkRoomCard";
 import HaveNotData from "@/app/components/HaveNotData/HaveNotData";
+import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
 import { useGetRoomLike } from "@/hook/reactQuery/talkRoom/useGetRoomLike";
 import { useGetRooms } from "@/hook/reactQuery/talkRoom/useGetRooms";
 import { useLogin } from "@/hook/useLogin";
@@ -11,6 +12,9 @@ const RoomCards = () => {
   const { data: talkRoomLikeIds } = isLoggedIn
     ? useGetRoomLike()
     : { data: { talkRoomIds: [] } };
+  const { data: myDetailData } = isLoggedIn
+    ? useGetMyDetail()
+    : { data: { userId: -1, userImage: "", userName: "" } };
   const { data: bookData, isLoading } = useGetRooms({
     page: 1,
     size: 6,
@@ -35,6 +39,7 @@ const RoomCards = () => {
               <TalkRoomCard
                 key={data.id}
                 data={data}
+                userId={myDetailData?.userId || -1}
                 isBest={false}
                 isLike={isLike}
               />

--- a/src/app/summary/talkroom/_component/MyTalkRoom.tsx
+++ b/src/app/summary/talkroom/_component/MyTalkRoom.tsx
@@ -2,6 +2,7 @@
 
 import TalkRoomCard from "@/app/components/Card/MainPageCard/TalkRoomCard";
 import HaveNotData from "@/app/components/HaveNotData/HaveNotData";
+import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
 import { useGetRoomLike } from "@/hook/reactQuery/talkRoom/useGetRoomLike";
 import { useGetRooms } from "@/hook/reactQuery/talkRoom/useGetRooms";
 import { useLogin } from "@/hook/useLogin";
@@ -14,6 +15,9 @@ const MyTalkRoom = () => {
   const { data: talkRoomLikeIds } = isLoggedIn
     ? useGetRoomLike()
     : { data: { talkRoomIds: [] } };
+  const { data: myDetailData } = isLoggedIn
+    ? useGetMyDetail()
+    : { data: { userId: -1, userImage: "", userName: "" } };
   const { tab } = useContext(TabContext);
   const { data: talkRoomPopular } = useGetRooms({
     page: 1,
@@ -35,6 +39,7 @@ const MyTalkRoom = () => {
             return (
               <TalkRoomCard
                 key={data.id}
+                userId={myDetailData?.userId || -1}
                 data={data}
                 isBest={false}
                 isLike={isLike}

--- a/src/app/talkroom/[result]/page.tsx
+++ b/src/app/talkroom/[result]/page.tsx
@@ -2,6 +2,7 @@
 
 import HaveNotData from "@/app/components/HaveNotData/HaveNotData";
 import RecentMakeTalkRoom from "@/assets/img/recent-make-talk-room.svg";
+import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
 import { useGetRoomLike } from "@/hook/reactQuery/talkRoom/useGetRoomLike";
 import { useGetRooms } from "@/hook/reactQuery/talkRoom/useGetRooms";
 import { useLogin } from "@/hook/useLogin";
@@ -52,6 +53,9 @@ const page = ({ params }: { params: { result: string } }) => {
   const { data: talkRoomLikeIds } = isLoggedIn
     ? useGetRoomLike()
     : { data: { talkRoomIds: [] } };
+  const { data: myDetailData } = isLoggedIn
+    ? useGetMyDetail()
+    : { data: { userId: -1, userImage: "", userName: "" } };
   const search = decodeURIComponent(params.result);
   const {
     data: talkRoomPopular,
@@ -112,6 +116,7 @@ const page = ({ params }: { params: { result: string } }) => {
                 <TalkRoomCard
                   key={data.id}
                   data={data}
+                  userId={myDetailData?.userId || -1}
                   isBest={orderParam === "recommend"}
                   isLike={isLike}
                 />

--- a/src/app/talkroom/[result]/page.tsx
+++ b/src/app/talkroom/[result]/page.tsx
@@ -24,6 +24,7 @@ type TalkRoom = {
   likeCount: number;
   readingStatuses: string[];
   registeredDateTime: string;
+  creatorId: number;
 };
 
 const page = ({ params }: { params: { result: string } }) => {

--- a/src/app/talkroom/_component/SpeechBubble/MySpeechBubble.tsx
+++ b/src/app/talkroom/_component/SpeechBubble/MySpeechBubble.tsx
@@ -118,6 +118,7 @@ const SpeechBubble = ({ data }: SpeechBubbleProps) => {
         isOpen={showModal}
         onClose={closeModal}
         onConfirm={closeModal}
+        buttonTitle="확인"
       />
       <Modal
         title="의견 삭제"
@@ -125,6 +126,7 @@ const SpeechBubble = ({ data }: SpeechBubbleProps) => {
         isOpen={deleteShowModal}
         onClose={closeDeleteShowModal}
         onConfirm={deleteMyComment}
+        buttonTitle="삭제"
       />
     </div>
   );

--- a/src/app/talkroom/_component/SpeechBubble/SpeechBubble.tsx
+++ b/src/app/talkroom/_component/SpeechBubble/SpeechBubble.tsx
@@ -19,6 +19,7 @@ interface SpeechBubbleProps {
     commentLikeCount: number;
     commentImages: string[];
     registeredDateTime: string;
+    creatorId: number;
   };
   isLike: boolean;
 }

--- a/src/app/talkroom/_component/SpeechBubble/SpeechBubble.tsx
+++ b/src/app/talkroom/_component/SpeechBubble/SpeechBubble.tsx
@@ -122,18 +122,10 @@ const SpeechBubble = ({
         <BubbleArrow />
       </div>
 
-      {userId === -1 ? (
+      {userId === -1 && (
         <Modal
           title="로그인"
           content="로그인을 해야 이용할 수 있는 기능입니다"
-          isOpen={showModal}
-          onClose={closeModal}
-          onConfirm={closeModal}
-        />
-      ) : (
-        <Modal
-          title="좋아요 실패"
-          content="본인이 작성한 의견에는 좋아요를 할 수 없습니다"
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}

--- a/src/app/talkroom/_component/SpeechBubble/SpeechBubble.tsx
+++ b/src/app/talkroom/_component/SpeechBubble/SpeechBubble.tsx
@@ -1,3 +1,4 @@
+import Modal from "@/app/components/Modal/Modal";
 import BubbleArrow from "@/assets/img/bubble-arrow.svg";
 import LikeSpeechBubble from "@/assets/img/like-speech-bubble.svg";
 import NotLike from "@/assets/img/not-like.svg";
@@ -33,6 +34,7 @@ const SpeechBubble = ({
   const [isLike, setIsLike] = useState<boolean>(initialIsLike);
   const createCommentLike = useCreateCommentLike();
   const deleteCommentLike = useDeleteCommentLike();
+  const [showModal, setShowModal] = useState<boolean>(false);
 
   useEffect(() => {
     setCount(data.commentLikeCount);
@@ -40,7 +42,9 @@ const SpeechBubble = ({
   }, [data.commentLikeCount, initialIsLike]);
 
   const changeIsLike = () => {
-    if (data.creatorId !== userId) {
+    if (userId === -1) {
+      setShowModal(!showModal);
+    } else if (data.creatorId !== userId) {
       if (isLike) {
         deleteCommentLike.mutate(data.commentId);
         setCount((prevCount) => prevCount - 1);
@@ -50,9 +54,14 @@ const SpeechBubble = ({
       }
       setIsLike(!isLike);
     } else {
-      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
+      setShowModal(!showModal);
     }
   };
+
+  const closeModal = () => {
+    setShowModal(false);
+  };
+
   return (
     <div className="relative bg-[#fff] rounded-[15px] mb-[97px] font-Pretendard font-regular border border-[#F4E4CE]">
       <div className="pt-[20px] pb-[12px] mx-[20px]">
@@ -112,6 +121,24 @@ const SpeechBubble = ({
       <div className="absolute left-[5%] bottom-[-48.8px] w-[87px] h-[52px]">
         <BubbleArrow />
       </div>
+
+      {userId === -1 ? (
+        <Modal
+          title="로그인"
+          content="로그인을 해야 이용할 수 있는 기능입니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      ) : (
+        <Modal
+          title="좋아요 실패"
+          content="본인이 작성한 의견에는 좋아요를 할 수 없습니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+        />
+      )}
     </div>
   );
 };

--- a/src/app/talkroom/_component/SpeechBubble/SpeechBubble.tsx
+++ b/src/app/talkroom/_component/SpeechBubble/SpeechBubble.tsx
@@ -21,9 +21,14 @@ interface SpeechBubbleProps {
     registeredDateTime: string;
     creatorId: number;
   };
+  userId: number;
   isLike: boolean;
 }
-const SpeechBubble = ({ data, isLike: initialIsLike }: SpeechBubbleProps) => {
+const SpeechBubble = ({
+  data,
+  userId,
+  isLike: initialIsLike,
+}: SpeechBubbleProps) => {
   const [count, setCount] = useState<number>(data.commentLikeCount);
   const [isLike, setIsLike] = useState<boolean>(initialIsLike);
   const createCommentLike = useCreateCommentLike();
@@ -35,14 +40,18 @@ const SpeechBubble = ({ data, isLike: initialIsLike }: SpeechBubbleProps) => {
   }, [data.commentLikeCount, initialIsLike]);
 
   const changeIsLike = () => {
-    if (isLike) {
-      deleteCommentLike.mutate(data.commentId);
-      setCount((prevCount) => prevCount - 1);
+    if (data.creatorId !== userId) {
+      if (isLike) {
+        deleteCommentLike.mutate(data.commentId);
+        setCount((prevCount) => prevCount - 1);
+      } else {
+        createCommentLike.mutate(data.commentId);
+        setCount((prevCount) => prevCount + 1);
+      }
+      setIsLike(!isLike);
     } else {
-      createCommentLike.mutate(data.commentId);
-      setCount((prevCount) => prevCount + 1);
+      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
     }
-    setIsLike(!isLike);
   };
   return (
     <div className="relative bg-[#fff] rounded-[15px] mb-[97px] font-Pretendard font-regular border border-[#F4E4CE]">

--- a/src/app/talkroom/_component/SpeechBubble/SpeechBubble.tsx
+++ b/src/app/talkroom/_component/SpeechBubble/SpeechBubble.tsx
@@ -129,6 +129,7 @@ const SpeechBubble = ({
           isOpen={showModal}
           onClose={closeModal}
           onConfirm={closeModal}
+          buttonTitle="확인"
         />
       )}
     </div>

--- a/src/app/talkroom/_component/talkroomDetailMain.tsx
+++ b/src/app/talkroom/_component/talkroomDetailMain.tsx
@@ -16,8 +16,9 @@ import { useEffect, useState } from "react";
 
 interface TalkRoomId {
   talkRoomId: number;
+  userId: number;
 }
-const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId }) => {
+const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
   const { isLoggedIn } = useLogin();
   const { data: talkRoomLikeIds } = isLoggedIn
     ? useGetRoomLike()
@@ -39,14 +40,18 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId }) => {
   }, [talkroomOneData]);
 
   const changeIsLike = () => {
-    if (isLike) {
-      deleteTalkRoomLike.mutate(talkRoomId);
-      setCount((prevCount) => prevCount - 1);
+    if (talkroomOneData?.creatorId !== userId) {
+      if (isLike) {
+        deleteTalkRoomLike.mutate(talkRoomId);
+        setCount((prevCount) => prevCount - 1);
+      } else {
+        addTalkRoomLike.mutate(talkRoomId);
+        setCount((prevCount) => prevCount + 1);
+      }
+      setIsLike(!isLike);
     } else {
-      addTalkRoomLike.mutate(talkRoomId);
-      setCount((prevCount) => prevCount + 1);
+      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
     }
-    setIsLike(!isLike);
   };
 
   if (!talkroomOneData) {

--- a/src/app/talkroom/_component/talkroomDetailMain.tsx
+++ b/src/app/talkroom/_component/talkroomDetailMain.tsx
@@ -205,6 +205,7 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
               isOpen={showModal}
               onClose={closeModal}
               onConfirm={closeModal}
+              buttonTitle="확인"
             />
           ) : (
             <Modal
@@ -213,6 +214,7 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
               isOpen={showModal}
               onClose={closeModal}
               onConfirm={closeModal}
+              buttonTitle="확인"
             />
           )}
           <Modal
@@ -221,6 +223,7 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
             isOpen={deleteShowModal}
             onClose={closeDeleteShowModal}
             onConfirm={deleteMyRoom}
+            buttonTitle="삭제"
           />
         </div>
       )}

--- a/src/app/talkroom/_component/talkroomDetailMain.tsx
+++ b/src/app/talkroom/_component/talkroomDetailMain.tsx
@@ -1,5 +1,6 @@
 import HaveNotData from "@/app/components/HaveNotData/HaveNotData";
 import IconButton from "@/app/components/IconButton/IconButton";
+import Modal from "@/app/components/Modal/Modal";
 import BookTitleBigImg from "@/assets/img/book-title-big.svg";
 import Like from "@/assets/img/like.svg";
 import NoImage from "@/assets/img/no-image.png";
@@ -29,6 +30,7 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
   const [count, setCount] = useState<number>(0);
   const addTalkRoomLike = useCreateRoomLike();
   const deleteTalkRoomLike = useDeleteRoomLike();
+  const [showModal, setShowModal] = useState<boolean>(false);
   useEffect(() => {
     if (talkroomOneData) {
       setCount(talkroomOneData.likeCount);
@@ -40,7 +42,9 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
   }, [talkroomOneData]);
 
   const changeIsLike = () => {
-    if (talkroomOneData?.creatorId !== userId) {
+    if (userId === -1) {
+      setShowModal(!showModal);
+    } else if (talkroomOneData?.creatorId !== userId) {
       if (isLike) {
         deleteTalkRoomLike.mutate(talkRoomId);
         setCount((prevCount) => prevCount - 1);
@@ -50,13 +54,18 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
       }
       setIsLike(!isLike);
     } else {
-      alert("내가 쓴 글에는 좋아요를 할 수 없습니다.");
+      setShowModal(!showModal);
     }
   };
 
   if (!talkroomOneData) {
     return <HaveNotData content={"책의 정보가"} />;
   }
+
+  const closeModal = () => {
+    setShowModal(false);
+  };
+
   return (
     <>
       {talkroomOneData && (
@@ -163,6 +172,24 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
               <HaveNotData content="이미지가" />
             )}
           </div>
+
+          {userId === -1 ? (
+            <Modal
+              title="로그인"
+              content="로그인을 해야 이용할 수 있는 기능입니다"
+              isOpen={showModal}
+              onClose={closeModal}
+              onConfirm={closeModal}
+            />
+          ) : (
+            <Modal
+              title="좋아요 실패"
+              content="본인이 작성한 토크방에는 좋아요를 할 수 없습니다"
+              isOpen={showModal}
+              onClose={closeModal}
+              onConfirm={closeModal}
+            />
+          )}
         </div>
       )}
     </>

--- a/src/app/talkroom/_component/talkroomDetailMain.tsx
+++ b/src/app/talkroom/_component/talkroomDetailMain.tsx
@@ -1,6 +1,6 @@
 import HaveNotData from "@/app/components/HaveNotData/HaveNotData";
 import IconButton from "@/app/components/IconButton/IconButton";
-import BookTitleBihImg from "@/assets/img/book-title-big.svg";
+import BookTitleBigImg from "@/assets/img/book-title-big.svg";
 import Like from "@/assets/img/like.svg";
 import NoImage from "@/assets/img/no-image.png";
 import NotLike from "@/assets/img/not-like.svg";
@@ -106,7 +106,7 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId }) => {
 
                 <div className="flex items-center text-[#656565] mb-[20px] text-[28px]">
                   <div className="mr-[7px]">
-                    <BookTitleBihImg />
+                    <BookTitleBigImg />
                   </div>
                   {talkroomOneData.bookName}
                 </div>

--- a/src/app/talkroom/detail/[id]/page.tsx
+++ b/src/app/talkroom/detail/[id]/page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/app/components/Button/Button";
 import HaveNotData from "@/app/components/HaveNotData/HaveNotData";
 import MainThemeTitle from "@/app/components/MainThemeTitle/MainThemeTitle";
 import PopularTalkRoom from "@/assets/img/popular-talk-room.svg";
+import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
 import { useGetCommentLike } from "@/hook/reactQuery/talkRoom/useGetCommentLike";
 import { useGetComments } from "@/hook/reactQuery/talkRoom/useGetComments";
 import { useLogin } from "@/hook/useLogin";
@@ -27,7 +28,9 @@ const Page = ({ params }: { params: { id: number } }) => {
   const { data: commentLikeIds } = isLoggedIn
     ? useGetCommentLike()
     : { data: { commentIds: [] } };
-
+  const { data: myDetailData } = isLoggedIn
+    ? useGetMyDetail()
+    : { data: { userId: -1, userImage: "", userName: "" } };
   const { data: commentsData } = useGetComments(params.id);
   return (
     <div>
@@ -35,7 +38,10 @@ const Page = ({ params }: { params: { id: number } }) => {
         <PopularTalkRoom />
       </MainThemeTitle>
 
-      <TalkRoomDetailMain talkRoomId={params.id} />
+      <TalkRoomDetailMain
+        talkRoomId={params.id}
+        userId={myDetailData?.userId || -1}
+      />
 
       <hr className="border-[6px] border-[#F5EFE5] mt-[47px] mb-[42px]" />
 
@@ -87,7 +93,12 @@ const Page = ({ params }: { params: { id: number } }) => {
             isLoggedIn &&
             (commentLikeIds?.commentIds || []).includes(data.commentId);
           return (
-            <SpeechBubble key={data.commentId} data={data} isLike={isLike} />
+            <SpeechBubble
+              key={data.commentId}
+              data={data}
+              userId={myDetailData?.userId || -1}
+              isLike={isLike}
+            />
           );
         })
       ) : (

--- a/src/app/talkroom/detail/[id]/page.tsx
+++ b/src/app/talkroom/detail/[id]/page.tsx
@@ -9,6 +9,7 @@ import { useGetCommentLike } from "@/hook/reactQuery/talkRoom/useGetCommentLike"
 import { useGetComments } from "@/hook/reactQuery/talkRoom/useGetComments";
 import { useLogin } from "@/hook/useLogin";
 import Link from "next/link";
+import MySpeechBubble from "../../_component/SpeechBubble/MySpeechBubble";
 import SpeechBubble from "../../_component/SpeechBubble/SpeechBubble";
 import TalkRoomDetailMain from "../../_component/talkroomDetailMain";
 
@@ -85,20 +86,24 @@ const Page = ({ params }: { params: { id: number } }) => {
           : commentsData?.totalCount}
       </div>
 
-      {/* <BestSpeechBubble content={"베스트 토크 의견 내용 들어갈 곳 입니다."} /> */}
-
       {commentsData && commentsData.queryResponse.length > 0 ? (
         commentsData.queryResponse.map((data: CommentsData) => {
           const isLike =
             isLoggedIn &&
             (commentLikeIds?.commentIds || []).includes(data.commentId);
           return (
-            <SpeechBubble
-              key={data.commentId}
-              data={data}
-              userId={myDetailData?.userId || -1}
-              isLike={isLike}
-            />
+            <div key={data.commentId}>
+              {data.creatorId !== myDetailData?.userId ? (
+                <MySpeechBubble key={data.commentId} data={data} />
+              ) : (
+                <SpeechBubble
+                  key={data.commentId}
+                  data={data}
+                  userId={myDetailData?.userId || -1}
+                  isLike={isLike}
+                />
+              )}
+            </div>
           );
         })
       ) : (

--- a/src/app/talkroom/detail/[id]/page.tsx
+++ b/src/app/talkroom/detail/[id]/page.tsx
@@ -93,7 +93,7 @@ const Page = ({ params }: { params: { id: number } }) => {
             (commentLikeIds?.commentIds || []).includes(data.commentId);
           return (
             <div key={data.commentId}>
-              {data.creatorId !== myDetailData?.userId ? (
+              {data.creatorId === myDetailData?.userId ? (
                 <MySpeechBubble key={data.commentId} data={data} />
               ) : (
                 <SpeechBubble

--- a/src/app/talkroom/detail/[id]/page.tsx
+++ b/src/app/talkroom/detail/[id]/page.tsx
@@ -19,6 +19,7 @@ type CommentsData = {
   commentLikeCount: number;
   commentImages: string[];
   registeredDateTime: string;
+  creatorId: number;
 };
 
 const Page = ({ params }: { params: { id: number } }) => {

--- a/src/app/talkroom/page.tsx
+++ b/src/app/talkroom/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import RecentMakeTalkRoom from "@/assets/img/recent-make-talk-room.svg";
+import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
 import { useGetRoomLike } from "@/hook/reactQuery/talkRoom/useGetRoomLike";
 import { useGetRooms } from "@/hook/reactQuery/talkRoom/useGetRooms";
 import { useLogin } from "@/hook/useLogin";
@@ -50,6 +51,9 @@ const page = () => {
   const { data: talkRoomLikeIds } = isLoggedIn
     ? useGetRoomLike()
     : { data: { talkRoomIds: [] } };
+  const { data: myDetailData } = isLoggedIn
+    ? useGetMyDetail()
+    : { data: { userId: -1, userImage: "", userName: "" } };
   const {
     data: talkRoomPopular,
     isLoading,
@@ -97,6 +101,7 @@ const page = () => {
               return (
                 <TalkRoomCard
                   key={data.id}
+                  userId={myDetailData?.userId || -1}
                   data={data}
                   isBest={orderParam === "recommend"}
                   isLike={isLike}

--- a/src/app/talkroom/page.tsx
+++ b/src/app/talkroom/page.tsx
@@ -23,6 +23,7 @@ type TalkRoom = {
   likeCount: number;
   readingStatuses: string[];
   registeredDateTime: string;
+  creatorId: number;
 };
 
 const page = () => {

--- a/src/app/talkroom/related/[isbn]/page.tsx
+++ b/src/app/talkroom/related/[isbn]/page.tsx
@@ -6,6 +6,7 @@ import Pagination from "@/app/components/Pagination/Pagination";
 import { ThemeMain } from "@/app/components/Theme/Theme";
 import RecentMakeTalkRoom from "@/assets/img/recent-make-talk-room.svg";
 import { useGetBookRelatedTalkRoom } from "@/hook/reactQuery/book/useGetBookRelatedTalkRoom";
+import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
 import { useGetRoomLike } from "@/hook/reactQuery/talkRoom/useGetRoomLike";
 import { useLogin } from "@/hook/useLogin";
 import { usePathname } from "next/navigation";
@@ -30,6 +31,9 @@ const page = ({ params }: { params: { isbn: string } }) => {
   const { data: talkRoomLikeIds } = isLoggedIn
     ? useGetRoomLike()
     : { data: { talkRoomIds: [] } };
+  const { data: myDetailData } = isLoggedIn
+    ? useGetMyDetail()
+    : { data: { userId: -1, userImage: "", userName: "" } };
   const currentUrl = usePathname();
   const { data: relateData, isLoading } = useGetBookRelatedTalkRoom({
     isbn: params?.isbn,
@@ -60,6 +64,7 @@ const page = ({ params }: { params: { isbn: string } }) => {
                 <TalkRoomCard
                   key={data.id}
                   data={data}
+                  userId={myDetailData?.userId || -1}
                   isBest={false}
                   isLike={isLike}
                 />

--- a/src/app/talkroom/related/[isbn]/page.tsx
+++ b/src/app/talkroom/related/[isbn]/page.tsx
@@ -22,6 +22,7 @@ type TalkRoom = {
   likeCount: number;
   readingStatuses?: string[];
   registeredDateTime?: string;
+  creatorId: number;
 };
 
 const page = ({ params }: { params: { isbn: string } }) => {

--- a/src/assets/img/my-bubble-arrow.svg
+++ b/src/assets/img/my-bubble-arrow.svg
@@ -1,0 +1,4 @@
+<svg width="92" height="66" viewBox="0 0 92 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M90 64L2 9V1H60V9L90 64Z" fill="#F3F3F3" stroke="#80685D"/>
+<rect width="62" height="9" fill="#F3F3F3"/>
+</svg>

--- a/src/hook/reactQuery/book/useGetBookRelatedTalkRoom.ts
+++ b/src/hook/reactQuery/book/useGetBookRelatedTalkRoom.ts
@@ -21,6 +21,7 @@ type BookStateResponse = {
       likeCount: number;
       readingStatuses: string[];
       registeredDateTime?: string;
+      creatorId: number;
     },
   ];
   totalCount: number;

--- a/src/hook/reactQuery/book/useGetReview.ts
+++ b/src/hook/reactQuery/book/useGetReview.ts
@@ -7,6 +7,7 @@ type ReviewResponse = {
       {
         reviewId: number;
         ratingId: number;
+        creatorId: number;
         username: string;
         profileImage: string;
         reviewContent: string;

--- a/src/hook/reactQuery/my/useGetMyDetail.ts
+++ b/src/hook/reactQuery/my/useGetMyDetail.ts
@@ -1,0 +1,16 @@
+import axiosInstance from "@/app/api/requestApi";
+import { useQuery } from "@tanstack/react-query";
+
+type MyDetail = {
+  userId: number;
+  userImage: string;
+  userName: string;
+};
+
+export const useGetMyDetail = () => {
+  return useQuery<MyDetail>({
+    queryKey: ["detail"],
+    queryFn: () => axiosInstance.get(`/v1/users/me`).then((data) => data.data),
+    throwOnError: true,
+  });
+};

--- a/src/hook/reactQuery/talkRoom/useDeleteComment.ts
+++ b/src/hook/reactQuery/talkRoom/useDeleteComment.ts
@@ -8,7 +8,7 @@ export const useDeleteComment = () => {
       axiosInstance.delete(`/v1/comments/${commentId}`),
     onSuccess: (_, commentId) => {
       queryClient.invalidateQueries({
-        queryKey: ["talkroom", "like", commentId],
+        queryKey: ["talkroom", commentId],
       });
     },
   });

--- a/src/hook/reactQuery/talkRoom/useDeleteRoom.ts
+++ b/src/hook/reactQuery/talkRoom/useDeleteRoom.ts
@@ -1,16 +1,13 @@
 import axiosInstance from "@/app/api/requestApi";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-type DeleteRequest = {
-  talkRoomId: string;
-};
-
 export const useDeleteRoom = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (talkRoomId: DeleteRequest) =>
-      axiosInstance.delete(`/v1/talk-rooms?${talkRoomId}`),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["talkRoom"] }),
+    mutationFn: (talkRoomId: number) =>
+      axiosInstance.delete(`/v1/talk-rooms/${talkRoomId}`),
+    onSuccess: (_, talkRoomId) =>
+      queryClient.invalidateQueries({ queryKey: ["talkRoom", talkRoomId] }),
   });
 };

--- a/src/hook/reactQuery/talkRoom/useGetComments.ts
+++ b/src/hook/reactQuery/talkRoom/useGetComments.ts
@@ -9,8 +9,9 @@ type TalkRoomResponse = {
       profileImage: string;
       content: string;
       commentLikeCount: number;
-      commentImages: [];
+      commentImages: string[];
       registeredDateTime: string;
+      creatorId: number;
     },
   ];
   totalCount: number;

--- a/src/hook/reactQuery/talkRoom/useGetOneRoom.ts
+++ b/src/hook/reactQuery/talkRoom/useGetOneRoom.ts
@@ -18,6 +18,7 @@ type TalkRoomResponse = {
   readingStatuses: string[];
   registeredDateTime: string;
   images: string[];
+  creatorId: number;
 };
 
 export const useGetOneRoom = ({ talkRoomId }: TalkRoomRequest) => {

--- a/src/hook/reactQuery/talkRoom/useGetRooms.ts
+++ b/src/hook/reactQuery/talkRoom/useGetRooms.ts
@@ -27,6 +27,7 @@ type TalkRoom = {
   likeCount: number;
   readingStatuses: string[];
   registeredDateTime: string;
+  creatorId: number;
 };
 
 export const useGetRooms = ({


### PR DESCRIPTION
## 🤷‍♂️ 해결하려 했던 문제는 무엇인가요?
1. 데이터 추가로 인한 typescript 수정 작업
2. 비 로그인 시 동작 추가
3. 토크방, 의견, 평가에 대한 삭제 기능 추가
4. Modal 컴포넌트의 버튼 이름 수정
5. 기타 사용자 경험 개선 작업

## ⚒️ 무엇이 바뀌었나요?
1. 데이터 추가로 인한 typescript 수정 작업
 - creatorId 추가로 인한 수정 작업 진행
 - 해당 데이터로 내 글인지 에 대한 유무 판단 가능
2. 비 로그인 시 동작 추가
 - 비 로그인 시 할 수 없는 동작에 대해,  Modal 컴포넌트를 이용하여 사전 차단 작업 진행
3. 토크방, 의견, 평가에 대한 삭제 기능 추가
 - 각 항목에 대한 hook 수정 (코드 정리 및 엔드 포인트 변경으로 인한 수정 작업)
 - 내가 쓴 글인지에 대한 판별 작업 후 Modal을 추가하여 삭제 여부를 확인한 후, 삭제가 가능하도록 기능 추가
 - 의견의 경우 내가 쓴 글에 대한 말풍선에 대한 교체 작업 및 코드 수정
4 .Modal 컴포넌트의 버튼 이름 수정
 - 위의 작업 시 버튼의 이름이 조금씩 다를 수 있어 buttonTitle이라는 props를 추가하여 버튼 이름을 수정할 수 있게 변경
5. 기타 사용자 경험 개선 작업
 - 책 상세보기의 한 줄평 작성에서 작성 후 모달 창 이후 해당 화면을 새로고침 하도록 수정
 - 책 상태에서 상태 변경 시 바로 반영이 안되는 현상을 발견, 이를 useEffect와 refetch를 이용하여 바로 반영이 될 수 있도록 사용자 경험을 개선함

## 👏 이 부분에 집중해주셨음 좋겠어요!

## 📷 캡처 사진

## 📚 참고해주세요
- [ ] git pull