### PR TITLE
토크방 이미지가 화면을 덮게 나오는 현상 수정

### DIFF
--- a/src/app/talkroom/_component/talkroomDetailMain.tsx
+++ b/src/app/talkroom/_component/talkroomDetailMain.tsx
@@ -180,10 +180,11 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
                 {talkroomOneData.images.map((image: string, index: number) => (
                   <Image
                     key={`image_${index}`}
-                    className="w-[160px] h-[160px] border border-solid border-[#FBF7F0] rounded-[4px]"
+                    className="min-w-[160px] max-w-[160px] min-h-[160px] max-h-[160px] border border-solid border-[#FBF7F0] rounded-[4px]"
                     src={image}
                     alt="이미지"
-                    fill
+                    width={160}
+                    height={160}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## 🤷‍♂️ 해결하려 했던 문제는 무엇인가요?
토크방 이미지가 화면을 덮게 나오는 현상

## ⚒️ 무엇이 바뀌었나요?
토크방 이미지가 화면을 덮게 나오는 현상
 - Image태그에서 fill대신 width와 height의 값을 지정한 후, min, max로 해당 값을 한 번 더 사용함으로서 문제 해결

## 👏 이 부분에 집중해주셨음 좋겠어요!

## 📷 캡처 사진

## 📚 참고해주세요
- [ ] git pull