### PR TITLE
api 변경 및 추가로 해당 api와 관련된 부분의 수정 작업 및 추가 작업

### DIFF
--- a/src/app/book/[isbn]/page.tsx
+++ b/src/app/book/[isbn]/page.tsx
@@ -7,6 +7,7 @@ import BestSeller from "@/assets/img/best-seller.svg";
 import { useGetBookInformation } from "@/hook/reactQuery/book/useGetBookInformation";
 import { useGetBookRelatedTalkRoom } from "@/hook/reactQuery/book/useGetBookRelatedTalkRoom";
 import { useGetReview } from "@/hook/reactQuery/book/useGetReview";
+import { useGetReviewCount } from "@/hook/reactQuery/book/useGetReviewCount";
 import { useGetReviewLike } from "@/hook/reactQuery/book/useGetReviewLike";
 import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
 import { useGetRoomLike } from "@/hook/reactQuery/talkRoom/useGetRoomLike";
@@ -56,6 +57,7 @@ const page = ({ params }: { params: { isbn: string } }) => {
     useGetBookInformation({
       isbn: params.isbn,
     });
+  const { data: reviewCount } = useGetReviewCount(params.isbn);
   const totalRatingChange = useCallback(() => {
     refetchBookInformation();
   }, [refetchBookInformation]);
@@ -95,7 +97,7 @@ const page = ({ params }: { params: { isbn: string } }) => {
           <div className="flex flex-row mt-[63px] mb-[28px] items-center">
             <div className="flex flex-row gap-x-[19px] flex-grow text-[30px] font-SpoqaHanSansNeo items-center">
               <div className="font-bold">유저들의 평가</div>
-              <div className="font-medium text-[#74747B]">3000+</div>
+              <div className="font-medium text-[#74747B]">{reviewCount}</div>
             </div>
             <Link href={`/evaluation/${params.isbn}?order=like`}>
               <div className="text-[20px] text-[#74747B] font-Pretendard font-regular">

--- a/src/app/talkroom/_component/talkroomDetailMain.tsx
+++ b/src/app/talkroom/_component/talkroomDetailMain.tsx
@@ -10,7 +10,6 @@ import TitleThemeBigImg from "@/assets/img/theme-title-big.svg";
 import { useCreateRoomLike } from "@/hook/reactQuery/talkRoom/useCreateRoomLike";
 import { useDeleteRoom } from "@/hook/reactQuery/talkRoom/useDeleteRoom";
 import { useDeleteRoomLike } from "@/hook/reactQuery/talkRoom/useDeleteRoomLike";
-import { useGetOneRoom } from "@/hook/reactQuery/talkRoom/useGetOneRoom";
 import { useGetRoomLike } from "@/hook/reactQuery/talkRoom/useGetRoomLike";
 import { useLogin } from "@/hook/useLogin";
 import timeLapse from "@/util/timeLapse";
@@ -18,18 +17,32 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
-interface TalkRoomId {
-  talkRoomId: number;
+type TalkRoomData = {
+  data?: {
+    id: number;
+    profileImage: string;
+    username: string;
+    title: string;
+    content: string;
+    bookIsbn: string;
+    bookName: string;
+    bookThumbnail: string;
+    bookAuthor: string;
+    likeCount: number;
+    readingStatuses: string[];
+    registeredDateTime: string;
+    images: string[];
+    creatorId: number;
+  };
   userId: number;
-}
-const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
+};
+const talkroomDetailMain: React.FC<TalkRoomData> = ({ data, userId }) => {
   const router = useRouter();
   const { isLoggedIn } = useLogin();
   const { data: talkRoomLikeIds } = isLoggedIn
     ? useGetRoomLike()
     : { data: { talkRoomIds: [] } };
 
-  const { data: talkroomOneData } = useGetOneRoom({ talkRoomId });
   const [isLike, setIsLike] = useState<boolean>(false);
   const [count, setCount] = useState<number>(0);
   const [showModal, setShowModal] = useState<boolean>(false);
@@ -39,24 +52,23 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
   const deleteRoom = useDeleteRoom();
 
   useEffect(() => {
-    if (talkroomOneData) {
-      setCount(talkroomOneData.likeCount);
+    if (data) {
+      setCount(data.likeCount);
       setIsLike(
-        isLoggedIn &&
-          (talkRoomLikeIds?.talkRoomIds || []).includes(talkroomOneData?.id),
+        isLoggedIn && (talkRoomLikeIds?.talkRoomIds || []).includes(data?.id),
       );
     }
-  }, [talkroomOneData]);
+  }, [data]);
 
   const changeIsLike = () => {
     if (userId === -1) {
       setShowModal(!showModal);
-    } else if (talkroomOneData?.creatorId !== userId) {
+    } else if (data && data.creatorId !== userId) {
       if (isLike) {
-        deleteTalkRoomLike.mutate(talkRoomId);
+        deleteTalkRoomLike.mutate(data.id);
         setCount((prevCount) => prevCount - 1);
       } else {
-        addTalkRoomLike.mutate(talkRoomId);
+        addTalkRoomLike.mutate(data.id);
         setCount((prevCount) => prevCount + 1);
       }
       setIsLike(!isLike);
@@ -65,7 +77,7 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
     }
   };
 
-  if (!talkroomOneData) {
+  if (!data) {
     return <HaveNotData content={"책의 정보가"} />;
   }
 
@@ -74,7 +86,7 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
   };
 
   const deleteMyRoom = () => {
-    deleteRoom.mutate(talkRoomId, {
+    deleteRoom.mutate(data.id, {
       onSuccess: () => {
         router.push("/talkroom/?order=recent&page=1");
       },
@@ -86,149 +98,137 @@ const talkroomDetailMain: React.FC<TalkRoomId> = ({ talkRoomId, userId }) => {
   };
 
   return (
-    <>
-      {talkroomOneData && (
-        <div className="w-full min-h-[1194px] bg-[white] border-2 border-[#F4E4CE] rounded-[12px] flex flex-col font-Pretendard font-medium">
-          <div className="mx-[46px] mt-[44px]">
+    <div className="w-full min-h-[1194px] bg-[white] border-2 border-[#F4E4CE] rounded-[12px] flex flex-col font-Pretendard font-medium">
+      <div className="mx-[46px] mt-[44px]">
+        <div className="flex flex-col">
+          <div className="flex flex-col items-end">
             <div className="flex flex-col">
-              <div className="flex flex-col items-end">
-                <div className="flex flex-col">
-                  <div className="flex flex-col items-center">
-                    <IconButton onClick={changeIsLike}>
-                      {isLike ? (
-                        <>
-                          <Like width={26} height={24} />
-                          <div className="h-[16px] font-Inter font-regular text-[16px] text-[#F24D4D]">
-                            {count}
-                          </div>
-                        </>
-                      ) : (
-                        <>
-                          <NotLike width={26} height={24} />
-                          <div className="h-[16px] font-Inter font-regular text-[16px] text-[#656565]">
-                            {count}
-                          </div>
-                        </>
-                      )}
-                    </IconButton>
-                  </div>
-                </div>
-              </div>
               <div className="flex flex-col items-center">
-                <div className="flex items-center text-[#000] mt-[6px] text-[30px] mb-4">
-                  <div className="mr-[7px]">
-                    <TitleThemeBigImg />
-                  </div>
-                  {talkroomOneData.title}
-                </div>
-                <div className="flex font-regular text-lg text-[#7E7E7E]">
-                  생성일: &nbsp;
-                  {timeLapse(talkroomOneData.registeredDateTime)}
-                </div>
-                <Image
-                  className="min-w-[260px] min-h-[339px] max-w-[260px] max-h-[339px]  border border-solid border-[#F4E4CE] my-[27px]"
-                  src={
-                    talkroomOneData && talkroomOneData.bookThumbnail
-                      ? talkroomOneData.bookThumbnail
-                      : NoImage
-                  }
-                  alt={"책표지"}
-                  width={223}
-                  height={291}
-                />
-
-                <div className="flex items-center text-[#656565] mb-[20px] text-[28px]">
-                  <div className="mr-[7px]">
-                    <BookTitleBigImg />
-                  </div>
-                  {talkroomOneData.bookName}
-                </div>
-              </div>
-              <div className="flex flex-col items-center mt-[19px] font-Pretendard font-medium text-lg text-[#FF6363]">
-                <div className="text-2xl mb-[7px]">참가조건</div>
-                <div className="flex flex-row gap-x-3 h-[30px]">
-                  {talkroomOneData.readingStatuses.map(
-                    (status: string, index: number) => (
-                      <div
-                        className="flex justify-center items-center w-auto h-[35px] text-[#656565] bg-[#FBF7F0] border border-[#F4E4CE] border-solid rounded-[4px] px-[9px] py-[7px]"
-                        key={index}
-                      >
-                        {status}
+                <IconButton onClick={changeIsLike}>
+                  {isLike ? (
+                    <>
+                      <Like width={26} height={24} />
+                      <div className="h-[16px] font-Inter font-regular text-[16px] text-[#F24D4D]">
+                        {count}
                       </div>
-                    ),
+                    </>
+                  ) : (
+                    <>
+                      <NotLike width={26} height={24} />
+                      <div className="h-[16px] font-Inter font-regular text-[16px] text-[#656565]">
+                        {count}
+                      </div>
+                    </>
                   )}
-                </div>
+                </IconButton>
               </div>
             </div>
-
-            <hr className="border border-solid border-[#F5EFE5] mt-[34px] mb-[25px]" />
-
-            <div className="min-h-[120px]">
-              <div className="font-semibold text-2xl mb-[5px]">
-                {talkroomOneData.title}
-              </div>
-              <div className="font-regular text-[22px] text-[#000]">
-                {talkroomOneData.content}
-              </div>
-            </div>
-
-            <hr className="border border-solid border-[#F5EFE5] mt-[25px] mb-[35px]" />
-
-            <div className="font-semibold text-2xl mb-[18px]">이미지</div>
-            {talkroomOneData.images.length > 0 ? (
-              <div className="flex gap-x-[23px] mb-10">
-                {talkroomOneData.images.map((image: string, index: number) => (
-                  <Image
-                    key={`image_${index}`}
-                    className="min-w-[160px] max-w-[160px] min-h-[160px] max-h-[160px] border border-solid border-[#FBF7F0] rounded-[4px]"
-                    src={image}
-                    alt="이미지"
-                    width={160}
-                    height={160}
-                  />
-                ))}
-              </div>
-            ) : (
-              <HaveNotData content="이미지가" />
-            )}
-
-            {talkroomOneData.creatorId === userId && (
-              <div className="flex justify-end  gap-x-3 mb-6">
-                <DeleteButton onClick={closeDeleteShowModal} />
-              </div>
-            )}
           </div>
+          <div className="flex flex-col items-center">
+            <div className="flex items-center text-[#000] mt-[6px] text-[30px] mb-4">
+              <div className="mr-[7px]">
+                <TitleThemeBigImg />
+              </div>
+              {data.title}
+            </div>
+            <div className="flex font-regular text-lg text-[#7E7E7E]">
+              생성일: &nbsp;
+              {timeLapse(data.registeredDateTime)}
+            </div>
+            <Image
+              className="min-w-[260px] min-h-[339px] max-w-[260px] max-h-[339px]  border border-solid border-[#F4E4CE] my-[27px]"
+              src={data.bookThumbnail || NoImage}
+              alt={"책표지"}
+              width={223}
+              height={291}
+            />
 
-          {userId === -1 ? (
-            <Modal
-              title="로그인"
-              content="로그인을 해야 이용할 수 있는 기능입니다"
-              isOpen={showModal}
-              onClose={closeModal}
-              onConfirm={closeModal}
-              buttonTitle="확인"
-            />
-          ) : (
-            <Modal
-              title="좋아요 실패"
-              content="본인이 작성한 토크방에는 좋아요를 할 수 없습니다"
-              isOpen={showModal}
-              onClose={closeModal}
-              onConfirm={closeModal}
-              buttonTitle="확인"
-            />
-          )}
-          <Modal
-            title="토크방 삭제"
-            content="토크방을 삭제하시겠습니까?"
-            isOpen={deleteShowModal}
-            onClose={closeDeleteShowModal}
-            onConfirm={deleteMyRoom}
-            buttonTitle="삭제"
-          />
+            <div className="flex items-center text-[#656565] mb-[20px] text-[28px]">
+              <div className="mr-[7px]">
+                <BookTitleBigImg />
+              </div>
+              {data.bookName}
+            </div>
+          </div>
+          <div className="flex flex-col items-center mt-[19px] font-Pretendard font-medium text-lg text-[#FF6363]">
+            <div className="text-2xl mb-[7px]">참가조건</div>
+            <div className="flex flex-row gap-x-3 h-[30px]">
+              {data.readingStatuses.map((status: string, index: number) => (
+                <div
+                  className="flex justify-center items-center w-auto h-[35px] text-[#656565] bg-[#FBF7F0] border border-[#F4E4CE] border-solid rounded-[4px] px-[9px] py-[7px]"
+                  key={index}
+                >
+                  {status}
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
+
+        <hr className="border border-solid border-[#F5EFE5] mt-[34px] mb-[25px]" />
+
+        <div className="min-h-[120px]">
+          <div className="font-semibold text-2xl mb-[5px]">{data.title}</div>
+          <div className="font-regular text-[22px] text-[#000]">
+            {data.content}
+          </div>
+        </div>
+
+        <hr className="border border-solid border-[#F5EFE5] mt-[25px] mb-[35px]" />
+
+        <div className="font-semibold text-2xl mb-[18px]">이미지</div>
+        {data.images.length > 0 ? (
+          <div className="flex gap-x-[23px] mb-10">
+            {data.images.map((image: string, index: number) => (
+              <Image
+                key={`image_${index}`}
+                className="min-w-[160px] max-w-[160px] min-h-[160px] max-h-[160px] border border-solid border-[#FBF7F0] rounded-[4px]"
+                src={image}
+                alt="이미지"
+                width={160}
+                height={160}
+              />
+            ))}
+          </div>
+        ) : (
+          <HaveNotData content="이미지가" />
+        )}
+
+        {data.creatorId === userId && (
+          <div className="flex justify-end  gap-x-3 mb-6">
+            <DeleteButton onClick={closeDeleteShowModal} />
+          </div>
+        )}
+      </div>
+
+      {userId === -1 ? (
+        <Modal
+          title="로그인"
+          content="로그인을 해야 이용할 수 있는 기능입니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+          buttonTitle="확인"
+        />
+      ) : (
+        <Modal
+          title="좋아요 실패"
+          content="본인이 작성한 토크방에는 좋아요를 할 수 없습니다"
+          isOpen={showModal}
+          onClose={closeModal}
+          onConfirm={closeModal}
+          buttonTitle="확인"
+        />
       )}
-    </>
+      <Modal
+        title="토크방 삭제"
+        content="토크방을 삭제하시겠습니까?"
+        isOpen={deleteShowModal}
+        onClose={closeDeleteShowModal}
+        onConfirm={deleteMyRoom}
+        buttonTitle="삭제"
+      />
+    </div>
   );
 };
 

--- a/src/app/talkroom/detail/[id]/page.tsx
+++ b/src/app/talkroom/detail/[id]/page.tsx
@@ -4,9 +4,11 @@ import { Button } from "@/app/components/Button/Button";
 import HaveNotData from "@/app/components/HaveNotData/HaveNotData";
 import MainThemeTitle from "@/app/components/MainThemeTitle/MainThemeTitle";
 import PopularTalkRoom from "@/assets/img/popular-talk-room.svg";
+import { useGetBookState } from "@/hook/reactQuery/book/useGetBookState";
 import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
 import { useGetCommentLike } from "@/hook/reactQuery/talkRoom/useGetCommentLike";
 import { useGetComments } from "@/hook/reactQuery/talkRoom/useGetComments";
+import { useGetOneRoom } from "@/hook/reactQuery/talkRoom/useGetOneRoom";
 import { useLogin } from "@/hook/useLogin";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -28,6 +30,8 @@ type CommentsData = {
 const Page = ({ params }: { params: { id: number } }) => {
   const { isLoggedIn } = useLogin();
   const [hydrated, setHydrated] = useState(false);
+  const { data: talkroomOneData } = useGetOneRoom({ talkRoomId: params.id });
+  const { data: getBookState } = isLoggedIn ? useGetBookState() : { data: [] };
   const { data: commentLikeIds } = isLoggedIn
     ? useGetCommentLike()
     : { data: { commentIds: [] } };
@@ -44,6 +48,16 @@ const Page = ({ params }: { params: { id: number } }) => {
     return null;
   }
 
+  const isCondition = (): boolean => {
+    if (!Array.isArray(getBookState)) {
+      return false;
+    }
+    return getBookState.some(
+      (book: { bookIsbn: string }) =>
+        book.bookIsbn === talkroomOneData?.bookIsbn,
+    );
+  };
+
   return (
     <div>
       <MainThemeTitle title="토크해요">
@@ -51,14 +65,14 @@ const Page = ({ params }: { params: { id: number } }) => {
       </MainThemeTitle>
 
       <TalkRoomDetailMain
-        talkRoomId={params.id}
+        data={talkroomOneData}
         userId={myDetailData?.userId || -1}
       />
 
       <hr className="border-[6px] border-[#F5EFE5] mt-[47px] mb-[42px]" />
 
       <div className="flex flex-col items-center mt-[37px] mb-[31px]">
-        {isLoggedIn ? (
+        {isLoggedIn && isCondition() ? (
           <>
             <div className="font-SpoqaHanSansNeo font-bold text-[#80685D] text-[30px] mb-[43px]">
               참가 조건에 부합하여 의견 작성이 가능합니다

--- a/src/hook/reactQuery/book/useCreateBookState.ts
+++ b/src/hook/reactQuery/book/useCreateBookState.ts
@@ -10,7 +10,7 @@ export const useCreateBookState = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (request: BookStateRequest) =>
-      axiosInstance.post(`/v1/user-libraries`, request),
+      axiosInstance.post(`/v1/libraries`, request),
     onSuccess: (_, { isbn }) =>
       queryClient.invalidateQueries({ queryKey: ["book", "state", isbn] }),
   });

--- a/src/hook/reactQuery/book/useDeleteBookState.ts
+++ b/src/hook/reactQuery/book/useDeleteBookState.ts
@@ -4,8 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 export const useDeleteBookState = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) =>
-      axiosInstance.delete(`/v1/user-libraries/${id}`),
+    mutationFn: (id: number) => axiosInstance.delete(`/v1/libraries/${id}`),
     onSuccess: (_, id) =>
       queryClient.invalidateQueries({ queryKey: ["book", "state", id] }),
   });

--- a/src/hook/reactQuery/book/useGetBookState.ts
+++ b/src/hook/reactQuery/book/useGetBookState.ts
@@ -3,17 +3,14 @@ import { useQuery } from "@tanstack/react-query";
 
 type BookStateResponse = {
   id: number;
+  bookIsbn: string;
   status: string;
-  hasReadingStatus: boolean;
 };
 
-export const useGetBookState = (isbn: string) => {
+export const useGetBookState = () => {
   return useQuery<BookStateResponse>({
-    queryKey: ["book", "state", isbn],
-    queryFn: () =>
-      axiosInstance
-        .get(`/v1/user-libraries?isbn=${isbn}`)
-        .then((data) => data.data),
+    queryKey: ["state"],
+    queryFn: () => axiosInstance.get(`/v1/libraries`).then((data) => data.data),
     throwOnError: true,
   });
 };

--- a/src/hook/reactQuery/book/useGetReviewCount.ts
+++ b/src/hook/reactQuery/book/useGetReviewCount.ts
@@ -1,0 +1,13 @@
+import axiosInstance from "@/app/api/requestApi";
+import { useQuery } from "@tanstack/react-query";
+
+export const useGetReviewCount = (isbn: string) => {
+  return useQuery({
+    queryKey: ["book", isbn],
+    queryFn: () =>
+      axiosInstance
+        .get(`/v1/books/${isbn}/reviews/count`)
+        .then((data) => data.data),
+    throwOnError: true,
+  });
+};

--- a/src/hook/reactQuery/book/usePatchBookState.ts
+++ b/src/hook/reactQuery/book/usePatchBookState.ts
@@ -10,7 +10,7 @@ export const usePatchBookState = (id: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (request: BookStateRequest) =>
-      axiosInstance.patch(`/v1/user-libraries/${id}`, request),
+      axiosInstance.patch(`/v1/libraries/${id}`, request),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["book", "state", id] }),
   });

--- a/src/hook/reactQuery/talkRoom/useGetOneRoom.ts
+++ b/src/hook/reactQuery/talkRoom/useGetOneRoom.ts
@@ -11,6 +11,7 @@ type TalkRoomResponse = {
   username: string;
   title: string;
   content: string;
+  bookIsbn: string;
   bookName: string;
   bookThumbnail: string;
   bookAuthor: string;


### PR DESCRIPTION
## 🤷‍♂️ 해결하려 했던 문제는 무엇인가요?
1. api 추가로 토크방의 의견 작성 로직 변경
2. api 추가로 책 상세보기의 의견 개수 추가
3. api 변경으로 책 상세보기에 대한 로직 변경

## ⚒️ 무엇이 바뀌었나요?
1. api 추가로 토크방의 의견 작성 로직 변경
 - 토크방에서 불러오는 데이터에 isbn이 추가
 - 해당 isbn을 이용하여 변경된 나의 서재 관리를 배열로 받아 isbn을 비교하는 some() 함수를 사용하여 일치 여부 확인
 - 이후 의견 작성에 해당 내용을 추가하여 로그인 && 일치 여부로 로직을 수정
2. api 추가로 책 상세보기의 의견 개수 추가
 - 의견 개수에 관한 api가 추가되어 의견 개수를 추가
3. api 변경으로 책 상세보기에 대한 로직 변경
 - api 변경으로 위에서 토크방 의견에 사용된 서재 관리를 배열로 받아 이를 이용해 기존의 방식과 다르게 수정함
 - 기존의 방식은 해당 isbn으로 id, isbn, status를 받아왔는데, 이제 배열에 모든 서재 정보를 받아오게 됨
 - 그러므로 배열을 비교하여 일치 여부를 확인 후 status를 반영하기로 함
 - 이때 쓰인 함수는 find()로 조건에 맞는 첫 번째 요소를 반환 받아 해당 정보를 기존의 로직처럼 이용하게 수정

## 👏 이 부분에 집중해주셨음 좋겠어요!

## 📷 캡처 사진

## 📚 참고해주세요
- [ ] git pull