### PR TITLE
메인 페이지 무한 스크롤 적용 및 hook 수정

### DIFF
--- a/src/app/components/Card/MainPageCard/BestSellerCard.tsx
+++ b/src/app/components/Card/MainPageCard/BestSellerCard.tsx
@@ -41,14 +41,14 @@ const BestSellerCard: React.FC<BestSellerCardProps> = ({
   talkRoomLikeIds,
   isLoading,
 }) => {
-  const { data: recentData, isLoading: dataIsLoading } = useGetRooms({
+  const { data: talkRoomData, isLoading: dataIsLoading } = useGetRooms({
     page: 1,
     size: 3,
     order: "recent",
     search: "",
     sortbydate: "",
   });
-  if (!isLoading && recentData?.queryResponse.length === 0)
+  if (!isLoading && talkRoomData?.pages[0].content.length === 0)
     return <HaveNotData content={"토크방이"} />;
   return (
     <div className="flex flex-row justify-center grow font-Pretendard text-[#000]">
@@ -77,9 +77,9 @@ const BestSellerCard: React.FC<BestSellerCardProps> = ({
         </BookMain>
       </Link>
       <div className="flex flex-col w-[370px]">
-        {recentData &&
-          recentData.queryResponse.length > 0 &&
-          recentData?.queryResponse.map((data: TalkRoom, index) => {
+        {talkRoomData &&
+          talkRoomData.pages[0].content.length > 0 &&
+          talkRoomData.pages[0].content.map((data: TalkRoom, index) => {
             const isLike = isLoggedIn && talkRoomLikeIds?.includes(data.id);
             return (
               <BestSellerTalkRoomCard

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,7 +82,7 @@ const page = () => {
             fetchNextPage();
           }
         },
-        { rootMargin: "0px" },
+        { rootMargin: "0px 0px -400px 0px" },
       );
       if (node) observer.current.observe(node);
     },

--- a/src/app/search/[word]/_component/RelativeRoomCards.tsx
+++ b/src/app/search/[word]/_component/RelativeRoomCards.tsx
@@ -3,7 +3,6 @@
 import TalkRoomCard from "@/app/components/Card/MainPageCard/TalkRoomCard";
 import HaveNotData from "@/app/components/HaveNotData/HaveNotData";
 import { useGetMyDetail } from "@/hook/reactQuery/my/useGetMyDetail";
-import { useGetRelativeReooms } from "@/hook/reactQuery/talkRoom/useGetRelativeTalkroom";
 import { useGetRoomLike } from "@/hook/reactQuery/talkRoom/useGetRoomLike";
 import { useGetRooms } from "@/hook/reactQuery/talkRoom/useGetRooms";
 import { useLogin } from "@/hook/useLogin";
@@ -26,9 +25,9 @@ const RelativeRoomCards = ({ name }: Props) => {
 
   return (
     <>
-      {bookData && bookData.queryResponse.length > 0 ? (
+      {bookData && bookData.pages[0].content.length > 0 ? (
         <div className="grid gap-8 grid-cols-3">
-          {bookData?.queryResponse.map((data: any) => {
+          {bookData?.pages[0].content.map((data: any) => {
             const isLike =
               isLoggedIn &&
               (talkRoomLikeIds?.talkRoomIds || []).includes(data.id);

--- a/src/app/search/[word]/_component/RoomCards.tsx
+++ b/src/app/search/[word]/_component/RoomCards.tsx
@@ -30,9 +30,9 @@ const RoomCards = ({ order = "recommend", search = "" }: Props) => {
 
   return (
     <>
-      {bookData && bookData.queryResponse.length > 0 ? (
+      {bookData && bookData.pages[0].content.length > 0 ? (
         <div className="grid gap-8 grid-cols-3">
-          {bookData?.queryResponse.map((data: any) => {
+          {bookData.pages[0].content.map((data: any) => {
             const isLike =
               isLoggedIn &&
               (talkRoomLikeIds?.talkRoomIds || []).includes(data.id);

--- a/src/app/talkroom/[result]/page.tsx
+++ b/src/app/talkroom/[result]/page.tsx
@@ -9,7 +9,6 @@ import { useLogin } from "@/hook/useLogin";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import TalkRoomCard from "../../components/Card/MainPageCard/TalkRoomCard";
-import Pagination from "../../components/Pagination/Pagination";
 import { ThemeMain } from "../../components/Theme/Theme";
 import TalkRoomSearch from "../_component/talkroomSearch";
 
@@ -105,10 +104,10 @@ const page = ({ params }: { params: { result: string } }) => {
         </div>
       </div>
 
-      {talkRoomPopular && talkRoomPopular.queryResponse.length > 0 ? (
+      {talkRoomPopular && talkRoomPopular.pages[0].content.length > 0 ? (
         <>
           <div className="flex flex-row flex-wrap gap-x-[40px] gap-y-[30px] w-[1295px]">
-            {talkRoomPopular.queryResponse.map((data: TalkRoom) => {
+            {talkRoomPopular.pages[0].content.map((data: TalkRoom) => {
               const isLike =
                 isLoggedIn &&
                 (talkRoomLikeIds?.talkRoomIds || []).includes(data.id);
@@ -123,20 +122,6 @@ const page = ({ params }: { params: { result: string } }) => {
               );
             })}
           </div>
-          {isLoading ? (
-            <></>
-          ) : (
-            <Pagination
-              totalItems={talkRoomPopular?.totalCount ?? 0}
-              postPage={12}
-              link={
-                sortByDate
-                  ? currentUrl +
-                    `?order=${orderParam}&search=${searchParam}&sortByDate=${sortByDate}`
-                  : currentUrl + `?order=${orderParam}&search=${searchParam}`
-              }
-            />
-          )}
         </>
       ) : (
         <HaveNotData content={"검색된 토크방이"} />

--- a/src/app/talkroom/page.tsx
+++ b/src/app/talkroom/page.tsx
@@ -9,7 +9,6 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import TalkRoomCard from "../components/Card/MainPageCard/TalkRoomCard";
 import HaveNotData from "../components/HaveNotData/HaveNotData";
-import Pagination from "../components/Pagination/Pagination";
 import { ThemeMain } from "../components/Theme/Theme";
 import TalkRoomSearch from "./_component/talkroomSearch";
 type TalkRoom = {
@@ -91,10 +90,10 @@ const page = () => {
         </div>
       </div>
 
-      {talkRoomPopular && talkRoomPopular.queryResponse.length > 0 ? (
+      {talkRoomPopular && talkRoomPopular.pages[0].content.length > 0 ? (
         <>
           <div className="flex flex-row flex-wrap gap-x-[40px] gap-y-[30px] w-[1295px]">
-            {talkRoomPopular.queryResponse.map((data: TalkRoom) => {
+            {talkRoomPopular.pages[0].content.map((data: TalkRoom) => {
               const isLike =
                 isLoggedIn &&
                 (talkRoomLikeIds?.talkRoomIds || []).includes(data.id);
@@ -109,19 +108,6 @@ const page = () => {
               );
             })}
           </div>
-          {isLoading ? (
-            <></>
-          ) : (
-            <Pagination
-              totalItems={talkRoomPopular?.totalCount ?? 0}
-              postPage={12}
-              link={
-                sortByDate
-                  ? currentUrl + `?order=${orderParam}&sortByDate=${sortByDate}`
-                  : currentUrl + `?order=${orderParam}`
-              }
-            />
-          )}
         </>
       ) : (
         <HaveNotData content={"토크방이"} />

--- a/src/hook/reactQuery/talkRoom/useGetRooms.ts
+++ b/src/hook/reactQuery/talkRoom/useGetRooms.ts
@@ -1,5 +1,5 @@
 import axiosInstance from "@/app/api/requestApi";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 type TalkRoomRequest = {
   page?: number;
@@ -10,9 +10,12 @@ type TalkRoomRequest = {
 };
 
 type TalkRoomInfo = {
-  queryResponse: TalkRoom[];
-  totalCount: number;
+  content: TalkRoom[];
+  hasContent: true;
+  number: number;
   size: number;
+  isFirst: boolean;
+  isLast: boolean;
 };
 
 type TalkRoom = {
@@ -31,20 +34,25 @@ type TalkRoom = {
 };
 
 export const useGetRooms = ({
-  page = 1,
-  size = 10,
+  size,
   order = "recent",
   search = "",
   sortbydate = "",
 }: TalkRoomRequest) => {
-  return useQuery<TalkRoomInfo>({
-    queryKey: ["talkroom", "popular", page, size, order, search, sortbydate],
-    queryFn: () =>
-      axiosInstance
+  return useInfiniteQuery<TalkRoomInfo, Error>({
+    queryKey: ["talkroom", "popular", size, order, search, sortbydate],
+    queryFn: async ({ pageParam = 1 }) => {
+      return axiosInstance
         .get(
-          `/v1/talk-rooms?page=${page}&size=${size}&order=${order}&search=${search}&day=${sortbydate}`,
+          `/v1/talk-rooms?page=${pageParam}&size=${size}&order=${order}&search=${search}&day=${sortbydate}`,
         )
-        .then(({ data }) => data),
-    throwOnError: true,
+        .then(({ data }) => data);
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.isLast) return undefined;
+      return lastPage.number + 1;
+    },
+    initialPageParam: 1,
+    throwOnError: false,
   });
 };


### PR DESCRIPTION
## 🤷‍♂️ 해결하려 했던 문제는 무엇인가요?
1. 무한 스크롤 적용을 위한 hook 수정
2. 메인 페이지에 적용
3. 수정한 hook과 관련된 페이지 수정

## ⚒️ 무엇이 바뀌었나요?
1. 무한 스크롤 적용을 위한 hook 수정
 - 기존의 useGetRooms hook을 무한 스크롤에 맞춰 수정
 - 이와 관련된 typescript 또한 같이 수정
2. 메인 페이지에 적용
 - 메인 페이지에 해당 무한 스크롤을 적용
 - 여기서 문제가 발생했는데...
     -  기존과 같은 코드이지만 페이지 끝에서 다음 데이터를 연달아 여러 번 호출하는 현상 발생
     - viewport 문제임을 확인하고 자연스럽게 하기 위한 viewport px을 재 설정 함으로써 해결함
3. 수정한 hook과 관련된 페이지 수정
 - 기존에 useGetRooms hook을 사용해서 일부 데이터를 가져오는 컴포넌트 들에 대하여 바뀐 형식에 맞춰 수정
 - 이후 작업에서 페이지네이션을 삭제 후 무한 스크롤을 사용할 컴포넌트에서 미리 페이지네이션을 삭제함

## 👏 이 부분에 집중해주셨음 좋겠어요!

## 📷 캡처 사진

## 📚 참고해주세요
- [ ] git pull