### PR TITLE
book search에서 발생하는 에러 해결

### DIFF
--- a/src/app/components/molecules/SearchedList/SearchedList.tsx
+++ b/src/app/components/molecules/SearchedList/SearchedList.tsx
@@ -32,7 +32,7 @@ const SearchedList = ({
   };
 
   const onRecentListClicked = (serach: string) => {
-    router.push(`/search/book?name=${serach}}`);
+    router.push(`/search/book?name=${serach}`);
   };
 
   const onRemoveClicked = (content: string) => {

--- a/src/app/search/[word]/_component/RelativeRoomCards.tsx
+++ b/src/app/search/[word]/_component/RelativeRoomCards.tsx
@@ -41,6 +41,7 @@ const RelativeRoomCards = ({ name }: Props) => {
     : { data: { userId: -1, userImage: "", userName: "" } };
   const { data: bookData, isLoading: isBookDataLoading } = useGetRooms({
     search: name,
+    size: 10,
   });
 
   return (


### PR DESCRIPTION
## 🤷‍♂️ 해결하려 했던 문제는 무엇인가요?
book saerch 페이지에서 탭에 있는 토크룸을 눌렀을 때, 네트워크 오류가 발생하는 에러 해결

## ⚒️ 무엇이 바뀌었나요?
인자로 size의 값을 지정해서 넘겨주지 않아서 발생했던 문제입니다!
size의 값을 지정해줌으로써 문제를 해결하였습니다.

추가적으로 search parameter에 '}' 토큰이 들어가는 현상도 수정했으니 체크해주시면 감사하겠습니다!
## 👏 이 부분에 집중해주셨음 좋겠어요!

## 📷 캡처 사진
![image](https://github.com/user-attachments/assets/6e6441ab-a1b0-4d82-970f-1f38e9c7d1a9)


## 📚 참고해주세요
x